### PR TITLE
Organize Java TP exercises by theme

### DIFF
--- a/exercices/README.md
+++ b/exercices/README.md
@@ -1,0 +1,20 @@
+# Parcours de Travaux Pratiques Java 21
+
+Ce dossier est organisé par grands thèmes du cours. Chaque sous-dossier contient des TPs successifs avec des exercices de difficulté croissante. Les TPs peuvent être réalisés indépendamment, mais ils sont pensés pour consolider progressivement toutes les notions du cours.
+
+| Thème | TPs disponibles |
+| --- | --- |
+| Fondamentaux du langage | [TP1](fondamentaux/TP1.md), [TP2](fondamentaux/TP2.md) |
+| Programmation orientée objet | [TP1](poo/TP1.md), [TP2](poo/TP2.md) |
+| Collections et génériques | [TP1](collections/TP1.md), [TP2](collections/TP2.md) |
+| Exceptions, fichiers et I/O | [TP1](exceptions-io/TP1.md), [TP2](exceptions-io/TP2.md) |
+| Programmation fonctionnelle et Java moderne | [TP1](fonctionnel-moderne/TP1.md), [TP2](fonctionnel-moderne/TP2.md) |
+| Projets intégrateurs | [TP1](projets-integres/TP1.md) |
+
+Chaque fiche de TP fournit :
+- **Objectifs pédagogiques** : compétences ciblées et prérequis.
+- **Mise en situation** : contexte métier ou technique réaliste.
+- **Série d'exercices** : plusieurs étapes graduelles pour construire une solution complète.
+- **Pistes d'extension** : idées pour aller plus loin, optionnelles.
+
+Bonne pratique !

--- a/exercices/collections/TP1.md
+++ b/exercices/collections/TP1.md
@@ -1,0 +1,26 @@
+# TP1 – Gestionnaire de tâches collaboratif
+
+## Objectifs pédagogiques
+- Utiliser `List`, `Set` et `Map` pour organiser des données.
+- Maîtriser les génériques et éviter les conversions de type.
+- Mettre en œuvre des algorithmes simples de tri et filtrage.
+
+## Mise en situation
+Vous développez un prototype de gestionnaire de tâches pour une équipe agile. Le système doit suivre les tâches, l'affectation et l'état d'avancement.
+
+## Exercices
+1. **Modèle de données**  
+   Créez un `record Task(String id, String titre, Status status, Set<String> labels)`. Définissez l'énumération `Status` (`TODO`, `IN_PROGRESS`, `DONE`).
+
+2. **Gestion via `List`**  
+   Implémentez une classe `TaskBoard` avec une `List<Task>` interne. Ajoutez des méthodes pour ajouter, supprimer par identifiant et rechercher par libellé. Assurez-vous que les opérations sont génériques et ne nécessitent pas de cast.
+
+3. **Indexation rapide**  
+   Ajoutez une `Map<String, Task>` pour l'accès direct par identifiant. Synchronisez la `Map` avec la `List` lors des opérations d'ajout/suppression.
+
+4. **Affichage trié**  
+   Fournissez une méthode `afficherParEtat()` qui retourne une `Map<Status, List<Task>>` triée par ordre de progression. Utilisez `Comparator` et `Collections.sort` ou `List.sort`.
+
+## Pistes d'extension
+- Introduire un `LinkedHashSet` pour conserver l'ordre d'insertion des libellés.
+- Ajouter un export CSV des tâches terminées.

--- a/exercices/collections/TP2.md
+++ b/exercices/collections/TP2.md
@@ -1,0 +1,26 @@
+# TP2 – Analyse de données financières
+
+## Objectifs pédagogiques
+- Exploiter les streams sur les collections.
+- Utiliser `Optional` pour gérer l'absence de valeur.
+- Mettre en place des structures adaptées aux recherches avancées.
+
+## Mise en situation
+Un cabinet de conseil doit analyser des transactions financières pour identifier des tendances et des anomalies. Vous devez préparer un module d'analyse.
+
+## Exercices
+1. **Structure de transactions**  
+   Définissez un `record Transaction(String id, String categorie, double montant, LocalDate date)`. Préparez une `List<Transaction>` de données d'exemple dans une classe `TransactionSamples`.
+
+2. **Statistiques par catégorie**  
+   Implémentez une méthode `Map<String, Double> totalParCategorie(List<Transaction>)` utilisant `Collectors.groupingBy` et `Collectors.summingDouble`.
+
+3. **Recherche conditionnelle**  
+   Créez une méthode `Optional<Transaction> rechercherPlusGrande(String categorie)` qui retourne la transaction la plus élevée pour une catégorie donnée via `max` et `Comparator`.
+
+4. **Détection d'anomalies**  
+   Filtrez les transactions supérieures à une moyenne glissante sur 7 jours. Stockez les alertes dans une `Deque<Transaction>` pour un traitement FIFO. Documentez le choix des structures dans les commentaires.
+
+## Pistes d'extension
+- Exporter un rapport formaté en JSON ou CSV.
+- Ajouter une interface pour brancher différents algorithmes de détection.

--- a/exercices/exceptions-io/TP1.md
+++ b/exercices/exceptions-io/TP1.md
@@ -1,0 +1,26 @@
+# TP1 – Gestion robuste des fichiers
+
+## Objectifs pédagogiques
+- Manipuler les API I/O classiques et NIO.2.
+- Gérer les exceptions avec `try-catch` et `try-with-resources`.
+- Organiser le code pour assurer la résilience des opérations disque.
+
+## Mise en situation
+Vous développez un outil de synchronisation de fichiers pour une petite équipe. La fiabilité prime sur la performance.
+
+## Exercices
+1. **Copie sécurisée**  
+   Implémentez une classe `FileCopier` avec une méthode `copier(Path source, Path destination)` utilisant `Files.newBufferedReader` et `Files.newBufferedWriter` dans un bloc `try-with-resources`. Gérez les `IOException` avec journalisation.
+
+2. **Vérification post-copie**  
+   Ajoutez une méthode `boolean verifierIntegrite(Path source, Path destination)` qui compare la taille et le hash (via `MessageDigest`). Lancez une exception personnalisée `IntegrityException` si le contrôle échoue.
+
+3. **Historique des opérations**  
+   Conservez un journal des copies réussies/échouées dans une `List<String>`. Sérialisez le journal dans un fichier texte via `Files.write` à la fin du programme.
+
+4. **WatchService de surveillance**  
+   Créez un composant `DirectoryWatcher` qui surveille un répertoire source et déclenche automatiquement `copier` lors de la création d'un nouveau fichier.
+
+## Pistes d'extension
+- Ajouter une option de synchronisation bidirectionnelle.
+- Gérer les fichiers binaires via des canaux (`FileChannel`).

--- a/exercices/exceptions-io/TP2.md
+++ b/exercices/exceptions-io/TP2.md
@@ -1,0 +1,26 @@
+# TP2 – Sérialisation et persistance avancée
+
+## Objectifs pédagogiques
+- Mettre en œuvre la sérialisation binaire et JSON.
+- Gérer plusieurs niveaux d'exceptions personnalisées.
+- Concevoir un module de persistance modulaire.
+
+## Mise en situation
+Une application de gestion de bibliothèque souhaite sauvegarder son catalogue localement et sur un service distant. Vous devez créer un module de persistance évolutif.
+
+## Exercices
+1. **Modèles sérialisables**  
+   Créez un `record Livre(String isbn, String titre, String auteur, LocalDate parution)` qui implémente `Serializable`. Ajoutez un `record Emprunt(Livre livre, LocalDate debut, LocalDate fin)`.
+
+2. **Sauvegarde binaire**  
+   Implémentez une classe `BinaryStorage` avec `sauvegarder(List<Emprunt>)` et `charger()` utilisant `ObjectOutputStream`/`ObjectInputStream`. Gérez les `IOException` et `ClassNotFoundException`.
+
+3. **Sauvegarde JSON**  
+   Créez une interface `CatalogStorage` et une implémentation `JsonStorage` (pseudo-code si aucune librairie externe). Utilisez `java.net.http.HttpClient` pour envoyer le JSON vers un service distant simulé (console ou stub).
+
+4. **Gestion des erreurs**  
+   Définissez une hiérarchie d'exceptions (`StorageException`, `RemoteStorageException`). Ajoutez une stratégie de retry avec journalisation lorsque l'envoi distant échoue.
+
+## Pistes d'extension
+- Implémenter un mécanisme de versionning du schéma.
+- Ajouter un mode de chiffrement optionnel lors de la sauvegarde.

--- a/exercices/fonctionnel-moderne/TP1.md
+++ b/exercices/fonctionnel-moderne/TP1.md
@@ -1,0 +1,26 @@
+# TP1 – Pipelines fonctionnels pour la data science
+
+## Objectifs pédagogiques
+- Manipuler les interfaces fonctionnelles standard.
+- Construire un pipeline complet avec l'API Stream.
+- Utiliser les `Collectors` pour produire des agrégats.
+
+## Mise en situation
+Une équipe data souhaite expérimenter une chaîne de transformation sur des mesures énergétiques. Vous devez fournir un prototype flexible.
+
+## Exercices
+1. **Génération de données**  
+   Créez un `Supplier<Double>` qui génère des mesures aléatoires. Utilisez `Stream.generate` pour produire 100 valeurs et stockez-les dans une `List<Double>`.
+
+2. **Filtrage et transformation**  
+   Définissez un `Predicate<Double>` pour filtrer les valeurs aberrantes (en dehors d'un intervalle). Transformez les mesures en `BigDecimal` via une `Function<Double, BigDecimal>` en arrondissant à deux décimales.
+
+3. **Agrégation**  
+   Utilisez `Collectors.summarizingDouble` pour obtenir des statistiques. Créez également un `Collector` personnalisé qui regroupe les mesures par tranche (`0-10`, `10-20`, etc.).
+
+4. **Visualisation textuelle**  
+   Consommez le flux avec un `Consumer<Map<String, Long>>` qui produit un histogramme textuel grâce aux text blocks.
+
+## Pistes d'extension
+- Intégrer `Optional` pour gérer l'absence de données.
+- Exporter le résultat dans un fichier via `Files.writeString`.

--- a/exercices/fonctionnel-moderne/TP2.md
+++ b/exercices/fonctionnel-moderne/TP2.md
@@ -1,0 +1,26 @@
+# TP2 – Java moderne et architecture modulaire
+
+## Objectifs pédagogiques
+- Utiliser les modules Java (Project Jigsaw).
+- Mettre en œuvre records, pattern matching et `switch` expressions.
+- Employer `HttpClient` et `CompletableFuture` pour des traitements asynchrones.
+
+## Mise en situation
+Vous développez un service de recommandations de livres pour une application mobile. Il doit agréger des données locales et distantes.
+
+## Exercices
+1. **Structure modulaire**  
+   Créez deux modules `com.app.catalog` et `com.app.reco`. Définissez les `module-info.java` nécessaires pour exporter les packages utiles.
+
+2. **Modèle de données moderne**  
+   Dans `com.app.catalog`, modélisez un `sealed interface Media permits Book, AudioBook`. `Book` et `AudioBook` sont des `record` avec des attributs pertinents.
+
+3. **Requêtes asynchrones**  
+   Dans `com.app.reco`, implémentez un service qui interroge une API distante simulée via `HttpClient` et `CompletableFuture`. Combinez les résultats avec le catalogue local.
+
+4. **Présentation intelligente**  
+   Créez une méthode `String decrire(Media media)` utilisant `switch` avec pattern matching pour différencier les types et générer un résumé localisé.
+
+## Pistes d'extension
+- Ajouter des tests modulaires avec `java --module-path`.
+- Intégrer un système de mise en cache avec `ConcurrentHashMap`.

--- a/exercices/fondamentaux/TP1.md
+++ b/exercices/fondamentaux/TP1.md
@@ -1,0 +1,26 @@
+# TP1 – Bases du langage : variables et structures de contrôle
+
+## Objectifs pédagogiques
+- Manipuler les types primitifs et les chaînes.
+- Utiliser les structures conditionnelles et les boucles.
+- Structurer un petit programme console selon les bonnes pratiques.
+
+## Mise en situation
+Vous devez réaliser un module de suivi de capteurs pour un laboratoire de météo amateur. Les données sont encore simulées, mais le code doit être propre et facilement maintenable.
+
+## Exercices
+1. **Initialisation des capteurs**  
+   Déclarez toutes les catégories de types primitifs nécessaires pour représenter un capteur (identifiant, emplacement, mesure, seuil critique, actif/inactif). Affichez un récapitulatif formaté en utilisant la concaténation ou `String.format`.
+
+2. **Logique d'alerte**  
+   Implémentez une méthode qui prend une mesure simulée et affiche un message d'état différent selon des seuils : "OK", "Attention" ou "Critique". Comparez une version utilisant `if/else` et une version avec `switch` expression.
+
+3. **Boucles de collecte**  
+   Simulez la collecte de 24 mesures horaires avec une boucle `for`. Calculez la moyenne journalière, la valeur maximale et indiquez si un dépassement de seuil est survenu. Isolez les calculs dans des méthodes dédiées pour respecter le principe DRY.
+
+4. **Reporting journalier**  
+   Combinez les résultats précédents dans une méthode `genererRapportJournalier()` qui retourne un bloc de texte (text block) présentant les statistiques. Ajoutez une option permettant de ré-exécuter la simulation tant que l'utilisateur répond `o` via une boucle `do/while`.
+
+## Pistes d'extension
+- Lire les paramètres de seuil depuis les arguments de ligne de commande.
+- Ajouter une validation pour empêcher les valeurs négatives lors de la saisie utilisateur.

--- a/exercices/fondamentaux/TP2.md
+++ b/exercices/fondamentaux/TP2.md
@@ -1,0 +1,26 @@
+# TP2 – Conception de services utilitaires
+
+## Objectifs pédagogiques
+- Concevoir des méthodes réutilisables.
+- Appliquer les principes KISS et séparation des responsabilités.
+- Écrire des tests de vérification simples via `main`.
+
+## Mise en situation
+Une petite start-up souhaite publier une bibliothèque utilitaire pour le traitement de données textuelles. Vous devez préparer un premier jet propre et documenté.
+
+## Exercices
+1. **Nettoyage et normalisation**  
+   Créez une classe `TextCleaner` avec des méthodes `trim`, `toTitleCase`, `removeAccents`. Chaque méthode doit être `static` et documentée via JavaDoc.
+
+2. **Analyse statistique**  
+   Ajoutez une classe `TextAnalyzer` avec une méthode `countWords(String)` qui renvoie une `Map<String, Integer>`. Introduisez une surcharge acceptant une liste de mots à ignorer.
+
+3. **Point d'entrée de démonstration**  
+   Écrivez une classe `DemoApp` avec une méthode `main` qui illustre l'utilisation des services. Utilisez des boucles pour présenter les résultats et comparez deux implémentations (brute vs refactorisée) pour mettre en avant la lisibilité.
+
+4. **Validation et tests rapides**  
+   Ajoutez des assertions (`Objects.requireNonNull`, `assert`) pour garantir la validité des entrées. Fournissez un scénario de test dans `main` qui couvre les cas limites.
+
+## Pistes d'extension
+- Transformer `TextAnalyzer` en classe immuable recevant la configuration via un constructeur.
+- Ajouter un mode interactif (lecture console) pour tester les méthodes.

--- a/exercices/poo/TP1.md
+++ b/exercices/poo/TP1.md
@@ -1,0 +1,26 @@
+# TP1 – Modélisation objet d'une animalerie
+
+## Objectifs pédagogiques
+- Manipuler classes, constructeurs et modificateurs d'accès.
+- Comprendre l'encapsulation et la visibilité des membres.
+- Illustrer l'héritage simple et la composition.
+
+## Mise en situation
+Vous devez concevoir le logiciel de gestion d'une petite animalerie. Le système doit être extensible car de nouveaux animaux seront ajoutés régulièrement.
+
+## Exercices
+1. **Classe de base `Animal`**  
+   Créez une classe abstraite `Animal` avec des attributs privés (`nom`, `age`, `poids`) et des getters protégés. Ajoutez une méthode abstraite `makeSound()` et une méthode finale `vieillir()` qui incrémente l'âge.
+
+2. **Implémentations spécialisées**  
+   Implémentez `Chien` et `Chat` en redéfinissant `makeSound()`. Ajoutez des comportements spécifiques (`rapporterObjet`, `faireSesGriffes`). Documentez via JavaDoc pourquoi certains attributs restent privés.
+
+3. **Gestionnaire d'enclos**  
+   Créez une classe `Enclos` contenant une `List<Animal>`. Fournissez des méthodes pour ajouter, retirer et nourrir les animaux. Utilisez l'encapsulation pour éviter que la liste ne soit modifiable de l'extérieur.
+
+4. **Simulation de visite**  
+   Écrivez une classe `AnimalerieApp` avec `main` qui instancie plusieurs animaux, les place dans des enclos et invoque leurs comportements polymorphes. Ajoutez un `switch` expression pour formater la description selon le type concret.
+
+## Pistes d'extension
+- Introduire une interface `Soignable` avec une méthode `soigner()` à implémenter.
+- Ajouter une classe `Oiseau` avec un comportement de vol et un suivi de la cage.

--- a/exercices/poo/TP2.md
+++ b/exercices/poo/TP2.md
@@ -1,0 +1,26 @@
+# TP2 – Architecture SOLID pour une boutique en ligne
+
+## Objectifs pédagogiques
+- Appliquer les principes SOLID.
+- Mettre en œuvre des interfaces et l'inversion de dépendances.
+- Utiliser les classes scellées et records pour modéliser des données modernes.
+
+## Mise en situation
+Vous conseillez une boutique en ligne souhaitant refondre son module de commande. Le code historique est monolithique et difficile à tester.
+
+## Exercices
+1. **Analyse du legacy**  
+   Partez d'une classe fictive `OrderProcessorLegacy` qui gère création, validation, paiement et expédition. Rédigez un court document (commentaires) listant les problèmes vis-à-vis de SOLID.
+
+2. **Refactorisation SRP/OCP**  
+   Créez des interfaces séparées (`OrderCreator`, `OrderValidator`, `OrderDispatcher`). Implémentez des classes concrètes respectant SRP. Montrez comment substituer une implémentation sans modifier le code client (OCP).
+
+3. **LSP et DIP**  
+   Introduisez une hiérarchie `sealed interface PaymentMethod permits CardPayment, WalletPayment`. Injectez la méthode de paiement via le constructeur d'un `CheckoutService`. Vérifiez que chaque implémentation respecte le contrat (LSP).
+
+4. **Test d'intégration léger**  
+   Écrivez un scénario `main` qui compose les services et traite plusieurs commandes. Utilisez des mocks simples (classes internes) pour simuler l'expédition et démontrer l'inversion de dépendances.
+
+## Pistes d'extension
+- Brancher un journal (`Logger`) injecté pour suivre les étapes.
+- Ajouter une implémentation de paiement différé avec validation supplémentaire.

--- a/exercices/projets-integres/TP1.md
+++ b/exercices/projets-integres/TP1.md
@@ -1,0 +1,33 @@
+# TP1 – Application console de bibliothèque modulaire
+
+## Objectifs pédagogiques
+- Combiner l'ensemble des notions abordées dans le cours.
+- Concevoir une architecture multi-modules complète.
+- Gérer la persistance, les flux et l'interaction utilisateur.
+
+## Mise en situation
+Vous livrez un MVP de gestion de bibliothèque pour un réseau de médiathèques. L'application doit fonctionner en mode console tout en restant facilement extensible.
+
+## Exercices
+1. **Architecture générale**  
+   Définissez trois modules : `com.biblio.core`, `com.biblio.storage`, `com.biblio.cli`. Décrivez les dépendances via `module-info.java` et la structure de packages.
+
+2. **Modèle métier**  
+   Dans `com.biblio.core`, implémentez des `record` pour `Livre`, `Utilisateur`, `Emprunt`. Ajoutez une classe scellée `CatalogueEvent` (`LivreCree`, `LivreMisAJour`, `LivreSupprime`).
+
+3. **Gestion des données**  
+   Dans `com.biblio.storage`, fournissez des adaptateurs pour :
+   - stockage fichier (NIO.2 + sérialisation JSON ou texte),
+   - stockage mémoire (collections),
+   - synchronisation distante simulée (`HttpClient`).
+   Gérez les exceptions via une hiérarchie `StorageException`.
+
+4. **Interface utilisateur**  
+   Dans `com.biblio.cli`, créez un menu textuel (Text Blocks) permettant d'ajouter/rechercher des livres, d'enregistrer un emprunt et de générer un rapport via Streams (`groupingBy`).
+
+5. **Tests fonctionnels**  
+   Fournissez un script `main` qui enchaîne les cas d'usage principaux et valide le comportement (gestion des erreurs, relances utilisateur).
+
+## Pistes d'extension
+- Intégrer un module `com.biblio.analytics` exploitant les streams et `Optional`.
+- Ajouter un mécanisme de plugins via le Service Loader.


### PR DESCRIPTION
## Summary
- reorganize the exercise dossier into themed subdirectories containing TP markdown files
- craft progressive exercise roadmaps for fundamentals, OOP, collections, I/O, functional Java, and integrative projects
- add a central README that indexes each TP and clarifies objectives and structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e2db1f604c832a98ca6c69b4ba9600