### PR TITLE
Add correction projects for all Java exercises

### DIFF
--- a/exercices/collections/correction/TP1/pom.xml
+++ b/exercices/collections/correction/TP1/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.collections</groupId>
+    <artifactId>tp1-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/Status.java
+++ b/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/Status.java
@@ -1,0 +1,7 @@
+package com.exercices.collections.tp1;
+
+enum Status {
+    TODO,
+    IN_PROGRESS,
+    DONE
+}

--- a/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/Task.java
+++ b/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/Task.java
@@ -1,0 +1,6 @@
+package com.exercices.collections.tp1;
+
+import java.util.Set;
+
+public record Task(String id, String titre, Status status, Set<String> labels) {
+}

--- a/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/TaskBoard.java
+++ b/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/TaskBoard.java
@@ -1,0 +1,63 @@
+package com.exercices.collections.tp1;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class TaskBoard {
+
+    private final List<Task> tasks = new ArrayList<>();
+    private final Map<String, Task> index = new java.util.HashMap<>();
+
+    public void ajouter(Task task) {
+        Objects.requireNonNull(task);
+        if (index.containsKey(task.id())) {
+            throw new IllegalArgumentException("Une tâche avec cet identifiant existe déjà");
+        }
+        tasks.add(task);
+        index.put(task.id(), task);
+    }
+
+    public Optional<Task> supprimerParId(String id) {
+        Task removed = index.remove(id);
+        if (removed != null) {
+            tasks.removeIf(task -> task.id().equals(id));
+            return Optional.of(removed);
+        }
+        return Optional.empty();
+    }
+
+    public List<Task> rechercherParLabel(String label) {
+        return tasks.stream()
+                .filter(task -> task.labels().contains(label))
+                .collect(Collectors.toList());
+    }
+
+    public Optional<Task> rechercherParId(String id) {
+        return Optional.ofNullable(index.get(id));
+    }
+
+    public Map<Status, List<Task>> afficherParEtat() {
+        Map<Status, List<Task>> resultat = new EnumMap<>(Status.class);
+        for (Status status : Status.values()) {
+            resultat.put(status, new ArrayList<>());
+        }
+        for (Task task : tasks) {
+            resultat.get(task.status()).add(task);
+        }
+        Comparator<Task> comparator = Comparator.comparing(task -> task.titre().toLowerCase());
+        resultat.values().forEach(list -> list.sort(comparator));
+        return Collections.unmodifiableMap(resultat);
+    }
+
+    public List<Task> listerToutes() {
+        return Collections.unmodifiableList(tasks);
+    }
+}

--- a/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/TaskBoardDemo.java
+++ b/exercices/collections/correction/TP1/src/main/java/com/exercices/collections/tp1/TaskBoardDemo.java
@@ -1,0 +1,31 @@
+package com.exercices.collections.tp1;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class TaskBoardDemo {
+
+    private TaskBoardDemo() {
+    }
+
+    public static void main(String[] args) {
+        TaskBoard board = new TaskBoard();
+        board.ajouter(new Task("T1", "Configurer le repo", Status.TODO, Set.of("setup", "git")));
+        board.ajouter(new Task("T2", "Préparer la démo", Status.IN_PROGRESS, Set.of("demo")));
+        board.ajouter(new Task("T3", "Livrer la fonctionnalité", Status.DONE, Set.of("delivery", "demo")));
+
+        System.out.println("Rechercher par label 'demo' :");
+        List<Task> demoTasks = board.rechercherParLabel("demo");
+        demoTasks.forEach(task -> System.out.println(" - " + task));
+
+        Map<Status, List<Task>> parEtat = board.afficherParEtat();
+        parEtat.forEach((status, tasks) -> {
+            System.out.println(status + " :");
+            tasks.forEach(task -> System.out.println("  * " + task.titre()));
+        });
+
+        board.supprimerParId("T2");
+        System.out.println("Indexation directe : " + board.rechercherParId("T1"));
+    }
+}

--- a/exercices/collections/correction/TP2/pom.xml
+++ b/exercices/collections/correction/TP2/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.collections</groupId>
+    <artifactId>tp2-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/Transaction.java
+++ b/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/Transaction.java
@@ -1,0 +1,6 @@
+package com.exercices.collections.tp2;
+
+import java.time.LocalDate;
+
+public record Transaction(String id, String categorie, double montant, LocalDate date) {
+}

--- a/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/TransactionAnalyzer.java
+++ b/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/TransactionAnalyzer.java
@@ -1,0 +1,67 @@
+package com.exercices.collections.tp2;
+
+import java.time.LocalDate;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.DoubleSummaryStatistics;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public final class TransactionAnalyzer {
+
+    private TransactionAnalyzer() {
+    }
+
+    public static Map<String, Double> totalParCategorie(List<Transaction> transactions) {
+        return transactions.stream()
+                .collect(Collectors.groupingBy(Transaction::categorie, Collectors.summingDouble(Transaction::montant)));
+    }
+
+    public static Optional<Transaction> rechercherPlusGrande(List<Transaction> transactions, String categorie) {
+        return transactions.stream()
+                .filter(t -> t.categorie().equalsIgnoreCase(categorie))
+                .max(java.util.Comparator.comparingDouble(Transaction::montant));
+    }
+
+    public static Deque<Transaction> detecterAnomalies(List<Transaction> transactions) {
+        Deque<Transaction> anomalies = new ArrayDeque<>();
+        transactions.stream()
+                .collect(Collectors.groupingBy(Transaction::categorie))
+                .values()
+                .forEach(list -> detecterParCategorie(list, anomalies));
+        return anomalies;
+    }
+
+    private static void detecterParCategorie(List<Transaction> transactions, Deque<Transaction> anomalies) {
+        transactions.stream()
+                .sorted(java.util.Comparator.comparing(Transaction::date))
+                .forEachOrdered(transaction -> {
+                    List<Transaction> fenetre = transactions.stream()
+                            .filter(t -> !t.date().isBefore(transaction.date().minusDays(7))
+                                    && !t.date().isAfter(transaction.date()))
+                            .toList();
+                    DoubleSummaryStatistics stats = fenetre.stream()
+                            .collect(Collectors.summarizingDouble(Transaction::montant));
+                    double moyenne = stats.getAverage();
+                    if (transaction.montant() > moyenne * 1.5) {
+                        anomalies.add(transaction);
+                    }
+                });
+    }
+
+    public static void afficherRapport(List<Transaction> transactions) {
+        System.out.println("Total par catégorie : " + totalParCategorie(transactions));
+        rechercherPlusGrande(transactions, "Courses").ifPresent(t ->
+                System.out.printf(Locale.FRANCE, "Plus grande transaction Courses : %.2f€ le %s%n", t.montant(), t.date()));
+        Deque<Transaction> anomalies = detecterAnomalies(transactions);
+        if (anomalies.isEmpty()) {
+            System.out.println("Aucune anomalie détectée");
+        } else {
+            System.out.println("Anomalies détectées (FIFO) :");
+            anomalies.forEach(t -> System.out.println(" - " + t));
+        }
+    }
+}

--- a/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/TransactionApp.java
+++ b/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/TransactionApp.java
@@ -1,0 +1,14 @@
+package com.exercices.collections.tp2;
+
+import java.util.List;
+
+public final class TransactionApp {
+
+    private TransactionApp() {
+    }
+
+    public static void main(String[] args) {
+        List<Transaction> transactions = TransactionSamples.demo();
+        TransactionAnalyzer.afficherRapport(transactions);
+    }
+}

--- a/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/TransactionSamples.java
+++ b/exercices/collections/correction/TP2/src/main/java/com/exercices/collections/tp2/TransactionSamples.java
@@ -1,0 +1,22 @@
+package com.exercices.collections.tp2;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public final class TransactionSamples {
+
+    private TransactionSamples() {
+    }
+
+    public static List<Transaction> demo() {
+        LocalDate today = LocalDate.now();
+        return List.of(
+                new Transaction("T1", "Courses", 82.5, today.minusDays(1)),
+                new Transaction("T2", "Loisirs", 45.0, today.minusDays(3)),
+                new Transaction("T3", "Courses", 23.7, today.minusDays(2)),
+                new Transaction("T4", "Transport", 60.0, today.minusDays(5)),
+                new Transaction("T5", "Courses", 120.0, today.minusDays(6)),
+                new Transaction("T6", "Transport", 15.0, today.minusDays(8))
+        );
+    }
+}

--- a/exercices/exceptions-io/correction/TP1/pom.xml
+++ b/exercices/exceptions-io/correction/TP1/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.exceptionsio</groupId>
+    <artifactId>tp1-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/DirectoryWatcher.java
+++ b/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/DirectoryWatcher.java
@@ -1,0 +1,50 @@
+package com.exercices.exceptionsio.tp1;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public final class DirectoryWatcher implements AutoCloseable {
+
+    private final WatchService watchService;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final FileCopier copier;
+    private final Path destinationDirectory;
+
+    public DirectoryWatcher(Path directory, FileCopier copier, Path destinationDirectory) throws IOException {
+        this.watchService = FileSystems.getDefault().newWatchService();
+        directory.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+        this.copier = copier;
+        this.destinationDirectory = destinationDirectory;
+    }
+
+    public void start(Path sourceDirectory) {
+        executor.submit(() -> {
+            try {
+                WatchKey key;
+                while ((key = watchService.take()) != null) {
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        Path created = sourceDirectory.resolve((Path) event.context());
+                        Path destination = destinationDirectory.resolve(created.getFileName());
+                        copier.copier(created, destination);
+                    }
+                    key.reset();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        executor.shutdownNow();
+        watchService.close();
+    }
+}

--- a/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/FileCopier.java
+++ b/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/FileCopier.java
@@ -1,0 +1,74 @@
+package com.exercices.exceptionsio.tp1;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class FileCopier {
+
+    private static final Logger LOGGER = Logger.getLogger(FileCopier.class.getName());
+    private final List<String> journal = new ArrayList<>();
+
+    public void copier(Path source, Path destination) {
+        try (Reader reader = Files.newBufferedReader(source);
+             Writer writer = Files.newBufferedWriter(destination)) {
+            reader.transferTo(writer);
+            journal.add("Copie réussie : " + source + " -> " + destination);
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Erreur de copie", e);
+            journal.add("Copie échouée : " + source + " -> " + destination + " : " + e.getMessage());
+        }
+    }
+
+    public boolean verifierIntegrite(Path source, Path destination) throws IntegrityException {
+        try {
+            long tailleSource = Files.size(source);
+            long tailleDestination = Files.size(destination);
+            if (tailleSource != tailleDestination) {
+                throw new IntegrityException("Tailles différentes");
+            }
+            String hashSource = calculerHash(source);
+            String hashDestination = calculerHash(destination);
+            if (!hashSource.equals(hashDestination)) {
+                throw new IntegrityException("Hash différents");
+            }
+            return true;
+        } catch (IOException e) {
+            throw new IntegrityException("Impossible de vérifier l'intégrité : " + e.getMessage());
+        }
+    }
+
+    private String calculerHash(Path path) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (var stream = Files.newInputStream(path)) {
+                byte[] buffer = stream.readAllBytes();
+                byte[] hash = digest.digest(buffer);
+                return HexFormat.of().formatHex(hash);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("Algorithme SHA-256 indisponible", e);
+        }
+    }
+
+    public void sauvegarderJournal(Path logPath) {
+        try {
+            Files.write(logPath, journal);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Impossible d'écrire le journal", e);
+        }
+    }
+
+    public List<String> journal() {
+        return List.copyOf(journal);
+    }
+}

--- a/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/FileSyncApp.java
+++ b/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/FileSyncApp.java
@@ -1,0 +1,39 @@
+package com.exercices.exceptionsio.tp1;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class FileSyncApp {
+
+    private FileSyncApp() {
+    }
+
+    public static void main(String[] args) throws IOException, IntegrityException {
+        Path tempDir = Files.createTempDirectory("source");
+        Path destDir = Files.createTempDirectory("dest");
+        Path sourceFile = tempDir.resolve("mesures.txt");
+        Files.writeString(sourceFile, "Mesures initiales");
+
+        FileCopier copier = new FileCopier();
+        Path destinationFile = destDir.resolve(sourceFile.getFileName());
+        copier.copier(sourceFile, destinationFile);
+        copier.verifierIntegrite(sourceFile, destinationFile);
+
+        Path logFile = destDir.resolve("journal.log");
+        copier.sauvegarderJournal(logFile);
+
+        try (DirectoryWatcher watcher = new DirectoryWatcher(tempDir, copier, destDir)) {
+            watcher.start(tempDir);
+            Files.writeString(tempDir.resolve("nouveau.txt"), "Hello watcher");
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        System.out.println("Journal : " + copier.journal());
+        System.out.println("Log écrit dans : " + logFile);
+    }
+}

--- a/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/IntegrityException.java
+++ b/exercices/exceptions-io/correction/TP1/src/main/java/com/exercices/exceptionsio/tp1/IntegrityException.java
@@ -1,0 +1,7 @@
+package com.exercices.exceptionsio.tp1;
+
+public class IntegrityException extends Exception {
+    public IntegrityException(String message) {
+        super(message);
+    }
+}

--- a/exercices/exceptions-io/correction/TP2/pom.xml
+++ b/exercices/exceptions-io/correction/TP2/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.exceptionsio</groupId>
+    <artifactId>tp2-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/BinaryStorage.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/BinaryStorage.java
@@ -1,0 +1,38 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class BinaryStorage {
+
+    private final Path fichier;
+
+    public BinaryStorage(Path fichier) {
+        this.fichier = fichier;
+    }
+
+    public void sauvegarder(List<Emprunt> emprunts) throws StorageException {
+        try (ObjectOutputStream output = new ObjectOutputStream(Files.newOutputStream(fichier))) {
+            output.writeObject(new ArrayList<>(emprunts));
+        } catch (IOException e) {
+            throw new StorageException("Impossible de sauvegarder", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Emprunt> charger() throws StorageException {
+        if (!Files.exists(fichier)) {
+            return List.of();
+        }
+        try (ObjectInputStream input = new ObjectInputStream(Files.newInputStream(fichier))) {
+            return (List<Emprunt>) input.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new StorageException("Impossible de charger", e);
+        }
+    }
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/CatalogStorage.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/CatalogStorage.java
@@ -1,0 +1,8 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.util.List;
+
+public interface CatalogStorage {
+    void sauvegarder(List<Emprunt> emprunts) throws StorageException;
+    List<Emprunt> charger() throws StorageException;
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/ConsoleHttpClient.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/ConsoleHttpClient.java
@@ -1,0 +1,144 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+final class ConsoleHttpClient extends HttpClient {
+
+    @Override
+    public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+        System.out.println("[Stub HTTP] " + request.method() + " " + request.uri());
+        return responseBodyHandler.apply(new HttpResponse.ResponseInfo() {
+            @Override
+            public int statusCode() {
+                return 200;
+            }
+
+            @Override
+            public HttpHeaders headers() {
+                return HttpHeaders.of(Map.of(), (a, b) -> true);
+            }
+
+            @Override
+            public Version version() {
+                return Version.HTTP_1_1;
+            }
+        }).body(new ByteArrayInputStream("OK".getBytes()));
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        return CompletableFuture.completedFuture(new HttpResponse<>() {
+            @Override
+            public int statusCode() {
+                return 200;
+            }
+
+            @Override
+            public HttpRequest request() {
+                return request;
+            }
+
+            @Override
+            public Optional<HttpResponse<T>> previousResponse() {
+                return Optional.empty();
+            }
+
+            @Override
+            public HttpHeaders headers() {
+                return HttpHeaders.of(Map.of(), (a, b) -> true);
+            }
+
+            @Override
+            public T body() {
+                return responseBodyHandler.apply(new HttpResponse.ResponseInfo() {
+                    @Override
+                    public int statusCode() {
+                        return 200;
+                    }
+
+                    @Override
+                    public HttpHeaders headers() {
+                        return HttpHeaders.of(Map.of(), (a, b) -> true);
+                    }
+
+                    @Override
+                    public Version version() {
+                        return Version.HTTP_1_1;
+                    }
+                }).body(new ByteArrayInputStream("OK".getBytes()));
+            }
+
+            @Override
+            public Optional<HttpHeaders> trailers() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Version version() {
+                return Version.HTTP_1_1;
+            }
+        });
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return Redirect.NEVER;
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return Optional.ofNullable(ProxySelector.getDefault());
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return null;
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return null;
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Version version() {
+        return Version.HTTP_1_1;
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return Optional.empty();
+    }
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/Emprunt.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/Emprunt.java
@@ -1,0 +1,7 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+public record Emprunt(Livre livre, LocalDate debut, LocalDate fin) implements Serializable {
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/JsonStorage.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/JsonStorage.java
@@ -1,0 +1,96 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public final class JsonStorage implements CatalogStorage {
+
+    private final HttpClient client;
+    private final Path fichierLocal;
+    private final URI endpoint;
+
+    public JsonStorage(Path fichierLocal, URI endpoint) {
+        this(HttpClient.newHttpClient(), fichierLocal, endpoint);
+    }
+
+    public JsonStorage(HttpClient client, Path fichierLocal, URI endpoint) {
+        this.client = client;
+        this.fichierLocal = fichierLocal;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public void sauvegarder(List<Emprunt> emprunts) throws StorageException {
+        String json = emprunts.stream()
+                .map(this::toJson)
+                .collect(Collectors.joining(",", "[", "]"));
+        try {
+            Files.writeString(fichierLocal, json);
+            envoyerVersRemote(json);
+        } catch (IOException e) {
+            throw new StorageException("Erreur d'écriture locale", e);
+        }
+    }
+
+    private void envoyerVersRemote(String json) throws RemoteStorageException {
+        HttpRequest request = HttpRequest.newBuilder(endpoint)
+                .timeout(Duration.ofSeconds(2))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+        AtomicInteger tentatives = new AtomicInteger();
+        while (tentatives.getAndIncrement() < 3) {
+            try {
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                    System.out.println("Envoi distant simulé : " + response.body());
+                    return;
+                }
+                throw new RemoteStorageException("Statut HTTP inattendu : " + response.statusCode());
+            } catch (IOException | InterruptedException e) {
+                if (tentatives.get() >= 3) {
+                    throw new RemoteStorageException("Echec d'envoi après retries", e);
+                }
+                try {
+                    Thread.sleep(250L * tentatives.get());
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new RemoteStorageException("Thread interrompu", ex);
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<Emprunt> charger() throws StorageException {
+        if (!Files.exists(fichierLocal)) {
+            return List.of();
+        }
+        try {
+            String json = Files.readString(fichierLocal);
+            return JsonSupport.fromJson(json);
+        } catch (IOException e) {
+            throw new StorageException("Lecture JSON impossible", e);
+        }
+    }
+
+    private String toJson(Emprunt emprunt) {
+        return "{" + "\"isbn\":\"" + emprunt.livre().isbn() + "\"," +
+                "\"titre\":\"" + emprunt.livre().titre() + "\"," +
+                "\"auteur\":\"" + emprunt.livre().auteur() + "\"," +
+                "\"parution\":\"" + emprunt.livre().parution() + "\"," +
+                "\"debut\":\"" + emprunt.debut() + "\"," +
+                "\"fin\":\"" + emprunt.fin() + "\"" +
+                "}";
+    }
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/JsonSupport.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/JsonSupport.java
@@ -1,0 +1,39 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+final class JsonSupport {
+
+    private JsonSupport() {
+    }
+
+    static List<Emprunt> fromJson(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        List<Emprunt> emprunts = new ArrayList<>();
+        String content = json.substring(1, json.length() - 1).trim();
+        if (content.isEmpty()) {
+            return List.of();
+        }
+        for (String entry : content.split("},")) {
+            String normalized = entry.replace("{", "").replace("}", "");
+            String[] parts = normalized.split(",");
+            String isbn = valueOf(parts[0]);
+            String titre = valueOf(parts[1]);
+            String auteur = valueOf(parts[2]);
+            LocalDate parution = LocalDate.parse(valueOf(parts[3]));
+            LocalDate debut = LocalDate.parse(valueOf(parts[4]));
+            LocalDate fin = LocalDate.parse(valueOf(parts[5]));
+            Livre livre = new Livre(isbn, titre, auteur, parution);
+            emprunts.add(new Emprunt(livre, debut, fin));
+        }
+        return emprunts;
+    }
+
+    private static String valueOf(String part) {
+        return part.substring(part.indexOf(':') + 2, part.length() - 1);
+    }
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/Livre.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/Livre.java
@@ -1,0 +1,7 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+public record Livre(String isbn, String titre, String auteur, LocalDate parution) implements Serializable {
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/PersistenceApp.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/PersistenceApp.java
@@ -1,0 +1,37 @@
+package com.exercices.exceptionsio.tp2;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+
+public final class PersistenceApp {
+
+    private PersistenceApp() {
+    }
+
+    public static void main(String[] args) throws StorageException {
+        Path binaire = Path.of("emprunts.bin");
+        BinaryStorage binaryStorage = new BinaryStorage(binaire);
+
+        List<Emprunt> emprunts = List.of(
+                new Emprunt(new Livre("978-2070368228", "1984", "George Orwell", LocalDate.of(1949, 6, 8)),
+                        LocalDate.now(), LocalDate.now().plusDays(21)),
+                new Emprunt(new Livre("978-2253006329", "Le Petit Prince", "Antoine de Saint-Exupéry", LocalDate.of(1943, 4, 6)),
+                        LocalDate.now().minusDays(2), LocalDate.now().plusDays(19))
+        );
+        binaryStorage.sauvegarder(emprunts);
+        System.out.println("Binaire chargé : " + binaryStorage.charger());
+
+        CatalogStorage jsonStorage = new JsonStorage(new ConsoleHttpClient(), Path.of("emprunts.json"), URI.create("https://biblio.local/api"));
+        jsonStorage.sauvegarder(emprunts);
+        System.out.println("JSON chargé : " + jsonStorage.charger());
+
+        try {
+            Files.deleteIfExists(binaire);
+            Files.deleteIfExists(Path.of("emprunts.json"));
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/RemoteStorageException.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/RemoteStorageException.java
@@ -1,0 +1,11 @@
+package com.exercices.exceptionsio.tp2;
+
+public class RemoteStorageException extends StorageException {
+    public RemoteStorageException(String message) {
+        super(message);
+    }
+
+    public RemoteStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/StorageException.java
+++ b/exercices/exceptions-io/correction/TP2/src/main/java/com/exercices/exceptionsio/tp2/StorageException.java
@@ -1,0 +1,11 @@
+package com.exercices.exceptionsio.tp2;
+
+public class StorageException extends Exception {
+    public StorageException(String message) {
+        super(message);
+    }
+
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/exercices/fonctionnel-moderne/correction/TP1/pom.xml
+++ b/exercices/fonctionnel-moderne/correction/TP1/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.fonctionnel</groupId>
+    <artifactId>tp1-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/fonctionnel-moderne/correction/TP1/src/main/java/com/exercices/fonctionnel/tp1/PipelineApp.java
+++ b/exercices/fonctionnel-moderne/correction/TP1/src/main/java/com/exercices/fonctionnel/tp1/PipelineApp.java
@@ -1,0 +1,67 @@
+package com.exercices.fonctionnel.tp1;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.DoubleSummaryStatistics;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+public final class PipelineApp {
+
+    private PipelineApp() {
+    }
+
+    public static void main(String[] args) {
+        Supplier<Double> generator = () -> ThreadLocalRandom.current().nextDouble(0, 50);
+        List<Double> mesures = Stream.generate(generator).limit(100).toList();
+        System.out.println("Mesures générées : " + mesures.size());
+
+        Predicate<Double> filtreIntervalle = value -> value >= 5 && value <= 45;
+        Function<Double, BigDecimal> arrondi = value -> BigDecimal.valueOf(value).setScale(2, RoundingMode.HALF_UP);
+
+        List<BigDecimal> nettoyees = mesures.stream()
+                .filter(filtreIntervalle)
+                .map(arrondi)
+                .toList();
+
+        DoubleSummaryStatistics stats = nettoyees.stream()
+                .mapToDouble(BigDecimal::doubleValue)
+                .summaryStatistics();
+        System.out.println("Statistiques : " + stats);
+
+        Collector<BigDecimal, ?, Map<String, Long>> trancheCollector = Collector.of(
+                LinkedHashMap::new,
+                (map, valeur) -> map.merge(tranchePour(valeur), 1L, Long::sum),
+                (left, right) -> {
+                    right.forEach((key, value) -> left.merge(key, value, Long::sum));
+                    return left;
+                }
+        );
+
+        Map<String, Long> histogramme = nettoyees.stream().collect(trancheCollector);
+        ConsumerAffichage.afficher(histogramme);
+    }
+
+    private static String tranchePour(BigDecimal valeur) {
+        int intervalle = valeur.intValue() / 10;
+        int min = intervalle * 10;
+        int max = min + 10;
+        return min + "-" + max;
+    }
+
+    private static final class ConsumerAffichage {
+        private static void afficher(Map<String, Long> histogramme) {
+            histogramme.forEach((tranche, count) -> {
+                String bar = "#".repeat(Math.toIntExact(count));
+                System.out.println(tranche + " : " + bar);
+            });
+        }
+    }
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/catalog/pom.xml
+++ b/exercices/fonctionnel-moderne/correction/TP2/catalog/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.app</groupId>
+        <artifactId>tp2-correction</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>catalog</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/AudioBook.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/AudioBook.java
@@ -1,0 +1,4 @@
+package com.app.catalog;
+
+public record AudioBook(String title, String author, int durationMinutes, String narrator) implements Media {
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/Book.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/Book.java
@@ -1,0 +1,4 @@
+package com.app.catalog;
+
+public record Book(String title, String author, int pages) implements Media {
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/CatalogService.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/CatalogService.java
@@ -1,0 +1,16 @@
+package com.app.catalog;
+
+import java.util.List;
+
+public final class CatalogService {
+
+    private final List<Media> medias = List.of(
+            new Book("Design Patterns", "GoF", 395),
+            new AudioBook("Clean Code", "Robert C. Martin", 750, "Narrateur Studio"),
+            new Book("Effective Java", "Joshua Bloch", 416)
+    );
+
+    public List<Media> listAll() {
+        return medias;
+    }
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/Media.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/com/app/catalog/Media.java
@@ -1,0 +1,6 @@
+package com.app.catalog;
+
+public sealed interface Media permits Book, AudioBook {
+    String title();
+    String author();
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/module-info.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/catalog/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module com.app.catalog {
+    exports com.app.catalog;
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/pom.xml
+++ b/exercices/fonctionnel-moderne/correction/TP2/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.app</groupId>
+    <artifactId>tp2-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>catalog</module>
+        <module>reco</module>
+    </modules>
+</project>

--- a/exercices/fonctionnel-moderne/correction/TP2/reco/pom.xml
+++ b/exercices/fonctionnel-moderne/correction/TP2/reco/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.app</groupId>
+        <artifactId>tp2-correction</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>reco</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.app</groupId>
+            <artifactId>catalog</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/com/app/reco/RecommendationApp.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/com/app/reco/RecommendationApp.java
@@ -1,0 +1,28 @@
+package com.app.reco;
+
+import com.app.catalog.AudioBook;
+import com.app.catalog.Book;
+import com.app.catalog.CatalogService;
+import com.app.catalog.Media;
+
+import java.util.concurrent.ExecutionException;
+
+public final class RecommendationApp {
+
+    private RecommendationApp() {
+    }
+
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        RecommendationService service = new RecommendationService(new CatalogService(), new StubRecommendationClient());
+        var medias = service.recomander().get();
+        medias.forEach(media -> System.out.println(decrire(media)));
+    }
+
+    public static String decrire(Media media) {
+        return switch (media) {
+            case Book book -> "Livre : %s par %s (%d pages)".formatted(book.title(), book.author(), book.pages());
+            case AudioBook audio -> "Livre audio : %s par %s (%d minutes) narré par %s".formatted(
+                    audio.title(), audio.author(), audio.durationMinutes(), audio.narrator());
+        };
+    }
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/com/app/reco/RecommendationService.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/com/app/reco/RecommendationService.java
@@ -1,0 +1,58 @@
+package com.app.reco;
+
+import com.app.catalog.CatalogService;
+import com.app.catalog.Media;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Stream;
+
+public final class RecommendationService {
+
+    private final CatalogService catalogService;
+    private final HttpClient httpClient;
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    public RecommendationService(CatalogService catalogService, HttpClient httpClient) {
+        this.catalogService = catalogService;
+        this.httpClient = httpClient;
+    }
+
+    public CompletableFuture<List<Media>> recomander() {
+        CompletableFuture<List<Media>> local = CompletableFuture.supplyAsync(catalogService::listAll, executor);
+        CompletableFuture<List<Media>> distant = appelerApiDistant();
+
+        return local.thenCombine(distant, (locaux, distants) -> Stream.concat(locaux.stream(), distants.stream())
+                .distinct()
+                .toList());
+    }
+
+    private CompletableFuture<List<Media>> appelerApiDistant() {
+        HttpRequest request = HttpRequest.newBuilder(URI.create("https://api.example.com/reco"))
+                .timeout(Duration.ofSeconds(1))
+                .GET()
+                .build();
+        return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(HttpResponse::body)
+                .exceptionally(ex -> "")
+                .thenApply(this::parseRemote);
+    }
+
+    private List<Media> parseRemote(String body) {
+        if (body == null || body.isBlank()) {
+            return List.of();
+        }
+        return body.lines()
+                .map(line -> line.split("\\|"))
+                .filter(parts -> parts.length >= 2)
+                .map(parts -> (Media) new com.app.catalog.Book(parts[0], parts[1], 250))
+                .toList();
+    }
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/com/app/reco/StubRecommendationClient.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/com/app/reco/StubRecommendationClient.java
@@ -1,0 +1,129 @@
+package com.app.reco;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+
+final class StubRecommendationClient extends HttpClient {
+
+    private static final String BODY = "La Horde du Contrevent|Alain Damasio\nLe Nom du Vent|Patrick Rothfuss";
+
+    @Override
+    public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+        return new SimpleResponse<>(request, (T) BODY);
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        return CompletableFuture.completedFuture(new SimpleResponse<>(request, (T) BODY));
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler,
+                                                            HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        return sendAsync(request, responseBodyHandler);
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return Redirect.NEVER;
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return Optional.empty();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return null;
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return null;
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Version version() {
+        return Version.HTTP_1_1;
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return Optional.empty();
+    }
+
+    private record SimpleResponse<T>(HttpRequest request, T body) implements HttpResponse<T> {
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public Optional<HttpResponse<T>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (a, b) -> true);
+        }
+
+        @Override
+        public T body() {
+            return body;
+        }
+
+        @Override
+        public Optional<SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return request.uri();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+    }
+}

--- a/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/module-info.java
+++ b/exercices/fonctionnel-moderne/correction/TP2/reco/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module com.app.reco {
+    requires com.app.catalog;
+    requires java.net.http;
+    exports com.app.reco;
+}

--- a/exercices/fondamentaux/correction/TP1/pom.xml
+++ b/exercices/fondamentaux/correction/TP1/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.fondamentaux</groupId>
+    <artifactId>tp1-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/AlertEvaluator.java
+++ b/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/AlertEvaluator.java
@@ -1,0 +1,26 @@
+package com.exercices.fondamentaux.tp1;
+
+final class AlertEvaluator {
+
+    private AlertEvaluator() {
+    }
+
+    static SensorStatus evaluateWithIfElse(double mesure, double seuil) {
+        if (mesure < seuil * 0.85) {
+            return SensorStatus.OK;
+        } else if (mesure < seuil) {
+            return SensorStatus.ATTENTION;
+        }
+        return SensorStatus.CRITIQUE;
+    }
+
+    static SensorStatus evaluateWithSwitch(double mesure, double seuil) {
+        double ratio = mesure / seuil;
+        return switch ((int) (ratio * 10)) {
+            case Integer.MIN_VALUE -> SensorStatus.CRITIQUE; // Sécurité
+            case 0, 1, 2, 3, 4, 5, 6, 7 -> SensorStatus.OK;
+            case 8, 9 -> SensorStatus.ATTENTION;
+            default -> SensorStatus.CRITIQUE;
+        };
+    }
+}

--- a/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/DailyReportGenerator.java
+++ b/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/DailyReportGenerator.java
@@ -1,0 +1,33 @@
+package com.exercices.fondamentaux.tp1;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.DoubleSummaryStatistics;
+import java.util.Locale;
+
+final class DailyReportGenerator {
+
+    private DailyReportGenerator() {
+    }
+
+    static String generateReport(Sensor sensor, double[] measures) {
+        DoubleSummaryStatistics stats = MeasurementSimulator.summarize(measures);
+        SensorStatus status = AlertEvaluator.evaluateWithIfElse(stats.getAverage(), sensor.seuilCritique());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss", Locale.FRANCE);
+
+        return String.format("""
+                Rapport du %s
+                Capteur : %s
+                Moyenne journalière : %.2f°C
+                Mesure maximale : %.2f°C
+                Dépassement de seuil : %s
+                Statut moyen : %s
+                """,
+                formatter.format(Instant.now()),
+                sensor.emplacement(),
+                stats.getAverage(),
+                stats.getMax(),
+                MeasurementSimulator.hasThresholdBreach(measures, sensor.seuilCritique()) ? "oui" : "non",
+                status);
+    }
+}

--- a/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/MeasurementSimulator.java
+++ b/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/MeasurementSimulator.java
@@ -1,0 +1,38 @@
+package com.exercices.fondamentaux.tp1;
+
+import java.security.SecureRandom;
+import java.util.DoubleSummaryStatistics;
+import java.util.List;
+import java.util.stream.DoubleStream;
+
+final class MeasurementSimulator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private MeasurementSimulator() {
+    }
+
+    static double[] simulateDay(double base, float seuil) {
+        return DoubleStream.iterate(base, prev -> prev + RANDOM.nextGaussian())
+                .limit(24)
+                .map(value -> Math.max(value, -20))
+                .map(value -> value + RANDOM.nextDouble(1.5))
+                .toArray();
+    }
+
+    static DoubleSummaryStatistics summarize(double[] values) {
+        return DoubleStream.of(values).summaryStatistics();
+    }
+
+    static boolean hasThresholdBreach(double[] values, float seuil) {
+        return DoubleStream.of(values).anyMatch(value -> value >= seuil);
+    }
+
+    static double highestMeasurement(double[] values) {
+        return DoubleStream.of(values).max().orElse(Double.NaN);
+    }
+
+    static List<Double> toList(double[] values) {
+        return DoubleStream.of(values).boxed().toList();
+    }
+}

--- a/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/Sensor.java
+++ b/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/Sensor.java
@@ -1,0 +1,21 @@
+package com.exercices.fondamentaux.tp1;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Représente un capteur avec les différentes catégories de types primitifs demandées.
+ */
+record Sensor(int id, String emplacement, double derniereMesure, float seuilCritique, boolean actif,
+              long serie, Instant derniereLecture) {
+
+    Sensor {
+        Objects.requireNonNull(emplacement, "emplacement");
+        Objects.requireNonNull(derniereLecture, "derniereLecture");
+    }
+
+    String toSummary() {
+        return String.format("Capteur #%d (%s)%n- Mesure actuelle : %.2f°C%n- Seuil critique : %.2f°C%n- Actif : %s%n- Série : %d%n- Dernière lecture : %s", id,
+                emplacement, derniereMesure, seuilCritique, actif ? "oui" : "non", serie, derniereLecture);
+    }
+}

--- a/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/SensorApp.java
+++ b/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/SensorApp.java
@@ -1,0 +1,38 @@
+package com.exercices.fondamentaux.tp1;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Scanner;
+
+/**
+ * Point d'entrée de démonstration pour le TP1.
+ */
+public final class SensorApp {
+
+    private SensorApp() {
+    }
+
+    public static void main(String[] args) {
+        Locale.setDefault(Locale.FRANCE);
+        try (Scanner scanner = new Scanner(System.in)) {
+            char reponse;
+            do {
+                Sensor sensor = new Sensor(42, "Laboratoire - Toit", 18.5, 22.0f, true, 2024001L, Instant.now());
+                System.out.println(sensor.toSummary());
+
+                double[] mesures = MeasurementSimulator.simulateDay(sensor.derniereMesure(), sensor.seuilCritique());
+                System.out.println("Mesures horaires : " + MeasurementSimulator.toList(mesures));
+
+                SensorStatus ifElseStatus = AlertEvaluator.evaluateWithIfElse(MeasurementSimulator.highestMeasurement(mesures), sensor.seuilCritique());
+                SensorStatus switchStatus = AlertEvaluator.evaluateWithSwitch(MeasurementSimulator.highestMeasurement(mesures), sensor.seuilCritique());
+                System.out.printf("Statut via if/else : %s | via switch : %s%n", ifElseStatus, switchStatus);
+
+                System.out.println(DailyReportGenerator.generateReport(sensor, mesures));
+
+                System.out.print("Relancer la simulation ? (o/n) : ");
+                String input = scanner.nextLine().trim().toLowerCase(Locale.ROOT);
+                reponse = input.isEmpty() ? 'n' : input.charAt(0);
+            } while (reponse == 'o');
+        }
+    }
+}

--- a/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/SensorStatus.java
+++ b/exercices/fondamentaux/correction/TP1/src/main/java/com/exercices/fondamentaux/tp1/SensorStatus.java
@@ -1,0 +1,7 @@
+package com.exercices.fondamentaux.tp1;
+
+enum SensorStatus {
+    OK,
+    ATTENTION,
+    CRITIQUE
+}

--- a/exercices/fondamentaux/correction/TP2/pom.xml
+++ b/exercices/fondamentaux/correction/TP2/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.fondamentaux</groupId>
+    <artifactId>tp2-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/fondamentaux/correction/TP2/src/main/java/com/exercices/fondamentaux/tp2/DemoApp.java
+++ b/exercices/fondamentaux/correction/TP2/src/main/java/com/exercices/fondamentaux/tp2/DemoApp.java
@@ -1,0 +1,47 @@
+package com.exercices.fondamentaux.tp2;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class DemoApp {
+
+    private DemoApp() {
+    }
+
+    public static void main(String[] args) {
+        Locale.setDefault(Locale.FRANCE);
+
+        String rawText = "   Java est un langage moderne. Java permet d'écrire du code moderne et robuste !   ";
+        System.out.println("Texte brut : " + rawText);
+
+        String cleaned = TextCleaner.trim(rawText);
+        String title = TextCleaner.toTitleCase(rawText);
+        String withoutAccents = TextCleaner.removeAccents("Éléphant à l'orée" );
+
+        System.out.printf("Nettoyé : '%s'%nTitre : '%s'%nSans accents : '%s'%n", cleaned, title, withoutAccents);
+
+        Set<String> ignored = Set.of("un", "et", "du");
+        Map<String, Integer> basicCount = TextAnalyzer.countWords(cleaned);
+        Map<String, Integer> filteredCount = TextAnalyzer.countWords(cleaned, ignored);
+
+        System.out.println("\nComptage brut :");
+        TextAnalyzer.printReport(basicCount);
+
+        System.out.println("\nComptage filtré :");
+        TextAnalyzer.printReport(filteredCount);
+
+        runAssertions(cleaned, withoutAccents, filteredCount);
+    }
+
+    private static void runAssertions(String cleaned, String withoutAccents, Map<String, Integer> filteredCount) {
+        Objects.requireNonNull(cleaned);
+        Objects.requireNonNull(withoutAccents);
+        Objects.requireNonNull(filteredCount);
+
+        assert cleaned.startsWith("Java") : "Le texte nettoyé doit débuter par Java";
+        assert withoutAccents.equals("Elephant a l'oree") : "Les accents doivent être retirés";
+        assert filteredCount.getOrDefault("java", 0) >= 2 : "Java doit être compté au moins deux fois";
+    }
+}

--- a/exercices/fondamentaux/correction/TP2/src/main/java/com/exercices/fondamentaux/tp2/TextAnalyzer.java
+++ b/exercices/fondamentaux/correction/TP2/src/main/java/com/exercices/fondamentaux/tp2/TextAnalyzer.java
@@ -1,0 +1,47 @@
+package com.exercices.fondamentaux.tp2;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Classe fournissant des statistiques simples sur un texte.
+ */
+public final class TextAnalyzer {
+
+    private TextAnalyzer() {
+    }
+
+    public static Map<String, Integer> countWords(String text) {
+        return countWords(text, Collections.emptySet());
+    }
+
+    public static Map<String, Integer> countWords(String text, Set<String> ignoredWords) {
+        Objects.requireNonNull(text, "text");
+        Objects.requireNonNull(ignoredWords, "ignoredWords");
+
+        List<String> words = Arrays.stream(text.split("\\W+"))
+                .map(String::toLowerCase)
+                .map(TextCleaner::trim)
+                .filter(word -> !word.isBlank())
+                .filter(word -> !ignoredWords.contains(word))
+                .toList();
+
+        return words.stream()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(w -> 1)))
+                .entrySet()
+                .stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, java.util.LinkedHashMap::new));
+    }
+
+    public static void printReport(Map<String, Integer> counts) {
+        counts.forEach((word, occurrences) -> System.out.printf(Locale.FRANCE, "%s -> %d%n", word, occurrences));
+    }
+}

--- a/exercices/fondamentaux/correction/TP2/src/main/java/com/exercices/fondamentaux/tp2/TextCleaner.java
+++ b/exercices/fondamentaux/correction/TP2/src/main/java/com/exercices/fondamentaux/tp2/TextCleaner.java
@@ -1,0 +1,58 @@
+package com.exercices.fondamentaux.tp2;
+
+import java.text.Normalizer;
+import java.util.Objects;
+
+/**
+ * Méthodes utilitaires pour nettoyer et normaliser des chaînes de caractères.
+ */
+public final class TextCleaner {
+
+    private TextCleaner() {
+    }
+
+    /**
+     * Supprime les espaces superflus en début et fin de chaîne.
+     *
+     * @param input texte d'origine
+     * @return texte sans espaces superflus
+     */
+    public static String trim(String input) {
+        return Objects.requireNonNull(input, "input").trim();
+    }
+
+    /**
+     * Met la chaîne au format Titre (première lettre en majuscule pour chaque mot).
+     *
+     * @param input texte d'origine
+     * @return texte formaté
+     */
+    public static String toTitleCase(String input) {
+        String trimmed = trim(input).toLowerCase();
+        StringBuilder builder = new StringBuilder(trimmed.length());
+        boolean capitalize = true;
+        for (char c : trimmed.toCharArray()) {
+            if (Character.isWhitespace(c) || c == '-') {
+                builder.append(c);
+                capitalize = true;
+            } else if (capitalize) {
+                builder.append(Character.toTitleCase(c));
+                capitalize = false;
+            } else {
+                builder.append(c);
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Retire les accents et autres diacritiques.
+     *
+     * @param input texte d'origine
+     * @return texte sans accents
+     */
+    public static String removeAccents(String input) {
+        String normalized = Normalizer.normalize(Objects.requireNonNull(input, "input"), Normalizer.Form.NFD);
+        return normalized.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+    }
+}

--- a/exercices/poo/correction/TP1/pom.xml
+++ b/exercices/poo/correction/TP1/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.poo</groupId>
+    <artifactId>tp1-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Animal.java
+++ b/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Animal.java
@@ -1,0 +1,43 @@
+package com.exercices.poo.tp1;
+
+/**
+ * Classe de base pour tous les animaux de l'animalerie.
+ */
+public abstract class Animal {
+
+    private final String nom;
+    private int age;
+    private double poids;
+
+    protected Animal(String nom, int age, double poids) {
+        this.nom = nom;
+        this.age = age;
+        this.poids = poids;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    protected int getAge() {
+        return age;
+    }
+
+    protected double getPoids() {
+        return poids;
+    }
+
+    protected void setPoids(double poids) {
+        this.poids = poids;
+    }
+
+    public final void vieillir() {
+        age++;
+    }
+
+    public abstract String makeSound();
+
+    public String description() {
+        return "%s (%d ans, %.1f kg)".formatted(nom, age, poids);
+    }
+}

--- a/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/AnimalerieApp.java
+++ b/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/AnimalerieApp.java
@@ -1,0 +1,38 @@
+package com.exercices.poo.tp1;
+
+import java.util.List;
+
+public final class AnimalerieApp {
+
+    private AnimalerieApp() {
+    }
+
+    public static void main(String[] args) {
+        Enclos enclosChiens = new Enclos("Chiens");
+        Enclos enclosChats = new Enclos("Chats");
+
+        Chien rex = new Chien("Rex", 3, 18.5);
+        Chat chipie = new Chat("Chipie", 2, 4.2);
+        Chat simba = new Chat("Simba", 4, 5.1);
+
+        enclosChiens.ajouter(rex);
+        enclosChats.ajouter(chipie);
+        enclosChats.ajouter(simba);
+
+        enclosChiens.nourrirTous();
+        enclosChats.nourrirTous();
+
+        List<Animal> tous = List.of(rex, chipie, simba);
+        for (Animal animal : tous) {
+            String description = switch (animal) {
+                case Chien chien -> chien.description() + " - " + chien.rapporterObjet("balle");
+                case Chat chat -> chat.description() + " - " + chat.faireSesGriffes();
+                default -> animal.description();
+            };
+            System.out.printf("%s : %s%n", animal.makeSound(), description);
+        }
+
+        System.out.println(enclosChiens);
+        enclosChiens.listerAnimaux().forEach(animal -> System.out.println(" - " + animal.description()));
+    }
+}

--- a/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Chat.java
+++ b/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Chat.java
@@ -1,0 +1,20 @@
+package com.exercices.poo.tp1;
+
+/**
+ * Implémentation concrète d'un chat.
+ */
+public final class Chat extends Animal {
+
+    public Chat(String nom, int age, double poids) {
+        super(nom, age, poids);
+    }
+
+    @Override
+    public String makeSound() {
+        return "Miaou";
+    }
+
+    public String faireSesGriffes() {
+        return "%s fait ses griffes".formatted(getNom());
+    }
+}

--- a/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Chien.java
+++ b/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Chien.java
@@ -1,0 +1,20 @@
+package com.exercices.poo.tp1;
+
+/**
+ * Implémentation concrète d'un chien.
+ */
+public final class Chien extends Animal {
+
+    public Chien(String nom, int age, double poids) {
+        super(nom, age, poids);
+    }
+
+    @Override
+    public String makeSound() {
+        return "Wouf !";
+    }
+
+    public String rapporterObjet(String objet) {
+        return "%s rapporte %s".formatted(getNom(), objet);
+    }
+}

--- a/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Enclos.java
+++ b/exercices/poo/correction/TP1/src/main/java/com/exercices/poo/tp1/Enclos.java
@@ -1,0 +1,39 @@
+package com.exercices.poo.tp1;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Gestionnaire d'enclos encapsulant la liste d'animaux.
+ */
+public final class Enclos {
+
+    private final String nom;
+    private final List<Animal> animaux = new ArrayList<>();
+
+    public Enclos(String nom) {
+        this.nom = nom;
+    }
+
+    public void ajouter(Animal animal) {
+        animaux.add(animal);
+    }
+
+    public boolean retirer(Animal animal) {
+        return animaux.remove(animal);
+    }
+
+    public void nourrirTous() {
+        animaux.forEach(animal -> animal.setPoids(animal.getPoids() + 0.1));
+    }
+
+    public List<Animal> listerAnimaux() {
+        return Collections.unmodifiableList(animaux);
+    }
+
+    @Override
+    public String toString() {
+        return "Enclos %s (%d animaux)".formatted(nom, animaux.size());
+    }
+}

--- a/exercices/poo/correction/TP2/pom.xml
+++ b/exercices/poo/correction/TP2/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.exercices.poo</groupId>
+    <artifactId>tp2-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/BasicOrderValidator.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/BasicOrderValidator.java
@@ -1,0 +1,16 @@
+package com.exercices.poo.tp2;
+
+import java.util.Objects;
+
+public final class BasicOrderValidator implements OrderValidator {
+    @Override
+    public void validate(Order order) {
+        Objects.requireNonNull(order);
+        if (order.customerEmail() == null || !order.customerEmail().contains("@")) {
+            throw new IllegalArgumentException("Email client invalide");
+        }
+        if (order.items().isEmpty()) {
+            throw new IllegalArgumentException("La commande doit contenir des articles");
+        }
+    }
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/CardPayment.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/CardPayment.java
@@ -1,0 +1,17 @@
+package com.exercices.poo.tp2;
+
+import java.time.YearMonth;
+
+public record CardPayment(String cardNumber, YearMonth expiry) implements PaymentMethod {
+    @Override
+    public boolean process(double amount) {
+        if (cardNumber == null || cardNumber.length() < 12) {
+            throw new IllegalArgumentException("Numéro de carte invalide");
+        }
+        if (YearMonth.now().isAfter(expiry)) {
+            throw new IllegalStateException("Carte expirée");
+        }
+        System.out.printf("Paiement carte de %.2f€ validé.%n", amount);
+        return true;
+    }
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/CheckoutScenario.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/CheckoutScenario.java
@@ -1,0 +1,24 @@
+package com.exercices.poo.tp2;
+
+import java.time.YearMonth;
+import java.util.List;
+
+public final class CheckoutScenario {
+
+    private CheckoutScenario() {
+    }
+
+    public static void main(String[] args) {
+        OrderCreator creator = new DefaultOrderCreator();
+        OrderValidator validator = new BasicOrderValidator();
+        OrderDispatcher dispatcher = order -> System.out.println("[MOCK] Expédition programmée pour " + order.id());
+        PaymentMethod paymentMethod = new CardPayment("123456789012", YearMonth.now().plusYears(2));
+
+        CheckoutService checkout = new CheckoutService(creator, validator, dispatcher, paymentMethod);
+        checkout.checkout("client@example.com", List.of("Livre", "Clavier"), 129.99);
+
+        PaymentMethod wallet = new WalletPayment("wallet-42", 200.0);
+        CheckoutService checkoutWallet = new CheckoutService(creator, validator, dispatcher, wallet);
+        checkoutWallet.checkout("client@example.com", List.of("Casque"), 59.0);
+    }
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/CheckoutService.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/CheckoutService.java
@@ -1,0 +1,29 @@
+package com.exercices.poo.tp2;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class CheckoutService {
+
+    private final OrderCreator orderCreator;
+    private final OrderValidator orderValidator;
+    private final OrderDispatcher dispatcher;
+    private final PaymentMethod paymentMethod;
+
+    public CheckoutService(OrderCreator orderCreator, OrderValidator orderValidator,
+                           OrderDispatcher dispatcher, PaymentMethod paymentMethod) {
+        this.orderCreator = Objects.requireNonNull(orderCreator);
+        this.orderValidator = Objects.requireNonNull(orderValidator);
+        this.dispatcher = Objects.requireNonNull(dispatcher);
+        this.paymentMethod = Objects.requireNonNull(paymentMethod);
+    }
+
+    public Order checkout(String customerEmail, List<String> items, double amount) {
+        Order order = orderCreator.create(customerEmail, items.toArray(String[]::new));
+        orderValidator.validate(order);
+        if (paymentMethod.process(amount)) {
+            dispatcher.dispatch(order);
+        }
+        return order;
+    }
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/DefaultOrderCreator.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/DefaultOrderCreator.java
@@ -1,0 +1,17 @@
+package com.exercices.poo.tp2;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class DefaultOrderCreator implements OrderCreator {
+    @Override
+    public Order create(String customerEmail, String... items) {
+        Objects.requireNonNull(customerEmail);
+        if (items == null || items.length == 0) {
+            throw new IllegalArgumentException("Une commande doit contenir au moins un article");
+        }
+        return new Order(UUID.randomUUID().toString(), customerEmail, Arrays.stream(items).toList(), Instant.now());
+    }
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/EmailOrderDispatcher.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/EmailOrderDispatcher.java
@@ -1,0 +1,10 @@
+package com.exercices.poo.tp2;
+
+import java.util.Locale;
+
+public final class EmailOrderDispatcher implements OrderDispatcher {
+    @Override
+    public void dispatch(Order order) {
+        System.out.printf(Locale.FRANCE, "Envoi de l'email à %s pour la commande %s%n", order.customerEmail(), order.id());
+    }
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/Order.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/Order.java
@@ -1,0 +1,7 @@
+package com.exercices.poo.tp2;
+
+import java.time.Instant;
+import java.util.List;
+
+public record Order(String id, String customerEmail, List<String> items, Instant createdAt) {
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderCreator.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderCreator.java
@@ -1,0 +1,5 @@
+package com.exercices.poo.tp2;
+
+public interface OrderCreator {
+    Order create(String customerEmail, String... items);
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderDispatcher.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderDispatcher.java
@@ -1,0 +1,5 @@
+package com.exercices.poo.tp2;
+
+public interface OrderDispatcher {
+    void dispatch(Order order);
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderProcessorLegacy.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderProcessorLegacy.java
@@ -1,0 +1,21 @@
+package com.exercices.poo.tp2;
+
+/**
+ * Exemple de code legacy concentrant trop de responsabilités.
+ *
+ * Violations SOLID :
+ * - SRP : création, validation, paiement et expédition sont dans la même classe.
+ * - OCP : impossible de changer un moyen de paiement sans modifier la classe.
+ * - LSP : aucune abstraction claire pour substituer un moyen de paiement.
+ * - ISP : les clients devraient dépendre d'opérations dont ils n'ont pas besoin.
+ * - DIP : dépend directement de classes concrètes (paiement, expédition).
+ */
+public final class OrderProcessorLegacy {
+
+    private OrderProcessorLegacy() {
+    }
+
+    public void process(Order order) {
+        throw new UnsupportedOperationException("Legacy non maintenable");
+    }
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderValidator.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/OrderValidator.java
@@ -1,0 +1,5 @@
+package com.exercices.poo.tp2;
+
+public interface OrderValidator {
+    void validate(Order order);
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/PaymentMethod.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/PaymentMethod.java
@@ -1,0 +1,5 @@
+package com.exercices.poo.tp2;
+
+sealed interface PaymentMethod permits CardPayment, WalletPayment {
+    boolean process(double amount);
+}

--- a/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/WalletPayment.java
+++ b/exercices/poo/correction/TP2/src/main/java/com/exercices/poo/tp2/WalletPayment.java
@@ -1,0 +1,12 @@
+package com.exercices.poo.tp2;
+
+public record WalletPayment(String walletId, double balance) implements PaymentMethod {
+    @Override
+    public boolean process(double amount) {
+        if (balance < amount) {
+            throw new IllegalStateException("Solde insuffisant");
+        }
+        System.out.printf("Paiement portefeuille de %.2f€ validé.%n", amount);
+        return true;
+    }
+}

--- a/exercices/projets-integres/correction/TP1/cli/pom.xml
+++ b/exercices/projets-integres/correction/TP1/cli/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.biblio</groupId>
+        <artifactId>tp1-correction</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>cli</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.biblio</groupId>
+            <artifactId>core</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.biblio</groupId>
+            <artifactId>storage</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/exercices/projets-integres/correction/TP1/cli/src/main/java/com/biblio/cli/BibliothequeCliApp.java
+++ b/exercices/projets-integres/correction/TP1/cli/src/main/java/com/biblio/cli/BibliothequeCliApp.java
@@ -1,0 +1,83 @@
+package com.biblio.cli;
+
+import com.biblio.core.CatalogueEvent;
+import com.biblio.core.CatalogueService;
+import com.biblio.core.Emprunt;
+import com.biblio.core.Livre;
+import com.biblio.core.Utilisateur;
+import com.biblio.storage.FileStorage;
+import com.biblio.storage.MemoryStorage;
+import com.biblio.storage.RemoteSynchronizer;
+import com.biblio.storage.StorageException;
+import com.biblio.storage.StubHttpClient;
+
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class BibliothequeCliApp {
+
+    private BibliothequeCliApp() {
+    }
+
+    public static void main(String[] args) throws StorageException {
+        CatalogueService catalogue = new CatalogueService();
+        MemoryStorage memoryStorage = new MemoryStorage();
+        FileStorage fileStorage = new FileStorage(Path.of("catalogue.txt"));
+        RemoteSynchronizer synchronizer = new RemoteSynchronizer(new StubHttpClient(), java.net.URI.create("https://biblio.local/api"));
+
+        afficherMenu();
+        scenarioDemonstration(catalogue, memoryStorage, fileStorage, synchronizer);
+    }
+
+    private static void afficherMenu() {
+        String menu = """
+                ============================
+                Bibliothèque – Menu principal
+                1. Ajouter un livre
+                2. Rechercher un livre
+                3. Enregistrer un emprunt
+                4. Générer un rapport
+                ============================
+                """;
+        System.out.println(menu);
+    }
+
+    private static void scenarioDemonstration(CatalogueService catalogue, MemoryStorage memoryStorage,
+                                              FileStorage fileStorage, RemoteSynchronizer synchronizer) throws StorageException {
+        Livre livre = new Livre("978-0134685991", "Effective Java", "Joshua Bloch", LocalDate.of(2018, 1, 6));
+        catalogue.ajouterLivre(livre);
+        catalogue.mettreAJourLivre(livre.isbn(), current -> new Livre(current.isbn(), current.titre() + " (3e éd.)", current.auteur(), current.parution()));
+
+        Utilisateur utilisateur = new Utilisateur("U1", "Alice", "alice@example.com");
+        Emprunt emprunt = new Emprunt(livre, utilisateur, LocalDate.now(), LocalDate.now().plusDays(21));
+        System.out.println("Emprunt enregistré : " + emprunt);
+
+        List<Livre> livres = catalogue.tous();
+        memoryStorage.sauvegarder(livres);
+        fileStorage.sauvegarder(livres);
+        synchronizer.envoyer(livres);
+
+        genererRapport(catalogue, List.of(emprunt));
+        afficherHistorique(catalogue.events());
+    }
+
+    private static void genererRapport(CatalogueService catalogue, List<Emprunt> emprunts) {
+        Map<String, Long> empruntsParUtilisateur = emprunts.stream()
+                .collect(Collectors.groupingBy(emprunt -> emprunt.utilisateur().nom(), Collectors.counting()));
+        String rapport = """
+                Rapport d'activité
+                ------------------
+                Livres en catalogue : %d
+                Emprunts par utilisateur : %s
+                """.formatted(catalogue.tous().size(), empruntsParUtilisateur);
+        System.out.println(rapport);
+    }
+
+    private static void afficherHistorique(List<CatalogueEvent> events) {
+        System.out.println("Historique des événements :");
+        events.forEach(event -> System.out.println(" - " + event));
+    }
+}

--- a/exercices/projets-integres/correction/TP1/cli/src/main/java/module-info.java
+++ b/exercices/projets-integres/correction/TP1/cli/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module com.biblio.cli {
+    requires com.biblio.core;
+    requires com.biblio.storage;
+}

--- a/exercices/projets-integres/correction/TP1/core/pom.xml
+++ b/exercices/projets-integres/correction/TP1/core/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.biblio</groupId>
+        <artifactId>tp1-correction</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>core</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+</project>

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/CatalogueEvent.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/CatalogueEvent.java
@@ -1,0 +1,5 @@
+package com.biblio.core;
+
+public sealed interface CatalogueEvent permits LivreCree, LivreMisAJour, LivreSupprime {
+    Livre livre();
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/CatalogueService.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/CatalogueService.java
@@ -1,0 +1,47 @@
+package com.biblio.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+public final class CatalogueService {
+
+    private final List<Livre> livres = new ArrayList<>();
+    private final List<CatalogueEvent> events = new ArrayList<>();
+
+    public void ajouterLivre(Livre livre) {
+        livres.add(livre);
+        events.add(new LivreCree(livre));
+    }
+
+    public void mettreAJourLivre(String isbn, UnaryOperator<Livre> updater) {
+        Optional<Livre> existant = trouverParIsbn(isbn);
+        existant.ifPresent(livre -> {
+            Livre misAJour = updater.apply(livre);
+            livres.remove(livre);
+            livres.add(misAJour);
+            events.add(new LivreMisAJour(misAJour));
+        });
+    }
+
+    public void supprimerLivre(String isbn) {
+        trouverParIsbn(isbn).ifPresent(livre -> {
+            livres.remove(livre);
+            events.add(new LivreSupprime(livre));
+        });
+    }
+
+    public Optional<Livre> trouverParIsbn(String isbn) {
+        return livres.stream().filter(livre -> livre.isbn().equals(isbn)).findFirst();
+    }
+
+    public List<Livre> tous() {
+        return Collections.unmodifiableList(livres);
+    }
+
+    public List<CatalogueEvent> events() {
+        return Collections.unmodifiableList(events);
+    }
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/Emprunt.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/Emprunt.java
@@ -1,0 +1,6 @@
+package com.biblio.core;
+
+import java.time.LocalDate;
+
+public record Emprunt(Livre livre, Utilisateur utilisateur, LocalDate dateDebut, LocalDate dateFin) {
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/Livre.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/Livre.java
@@ -1,0 +1,6 @@
+package com.biblio.core;
+
+import java.time.LocalDate;
+
+public record Livre(String isbn, String titre, String auteur, LocalDate parution) {
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/LivreCree.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/LivreCree.java
@@ -1,0 +1,4 @@
+package com.biblio.core;
+
+public record LivreCree(Livre livre) implements CatalogueEvent {
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/LivreMisAJour.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/LivreMisAJour.java
@@ -1,0 +1,4 @@
+package com.biblio.core;
+
+public record LivreMisAJour(Livre livre) implements CatalogueEvent {
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/LivreSupprime.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/LivreSupprime.java
@@ -1,0 +1,4 @@
+package com.biblio.core;
+
+public record LivreSupprime(Livre livre) implements CatalogueEvent {
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/Utilisateur.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/com/biblio/core/Utilisateur.java
@@ -1,0 +1,4 @@
+package com.biblio.core;
+
+public record Utilisateur(String id, String nom, String email) {
+}

--- a/exercices/projets-integres/correction/TP1/core/src/main/java/module-info.java
+++ b/exercices/projets-integres/correction/TP1/core/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module com.biblio.core {
+    exports com.biblio.core;
+}

--- a/exercices/projets-integres/correction/TP1/pom.xml
+++ b/exercices/projets-integres/correction/TP1/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.biblio</groupId>
+    <artifactId>tp1-correction</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>core</module>
+        <module>storage</module>
+        <module>cli</module>
+    </modules>
+</project>

--- a/exercices/projets-integres/correction/TP1/storage/pom.xml
+++ b/exercices/projets-integres/correction/TP1/storage/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.biblio</groupId>
+        <artifactId>tp1-correction</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>storage</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.biblio</groupId>
+            <artifactId>core</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/CatalogueStorage.java
+++ b/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/CatalogueStorage.java
@@ -1,0 +1,10 @@
+package com.biblio.storage;
+
+import com.biblio.core.Livre;
+
+import java.util.List;
+
+public interface CatalogueStorage {
+    void sauvegarder(List<Livre> livres) throws StorageException;
+    List<Livre> charger() throws StorageException;
+}

--- a/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/FileStorage.java
+++ b/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/FileStorage.java
@@ -1,0 +1,46 @@
+package com.biblio.storage;
+
+import com.biblio.core.Livre;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class FileStorage implements CatalogueStorage {
+
+    private final Path fichier;
+
+    public FileStorage(Path fichier) {
+        this.fichier = fichier;
+    }
+
+    @Override
+    public void sauvegarder(List<Livre> livres) throws StorageException {
+        String contenu = livres.stream()
+                .map(livre -> String.join(";", livre.isbn(), livre.titre(), livre.auteur(), livre.parution().toString()))
+                .collect(Collectors.joining(System.lineSeparator()));
+        try {
+            Files.writeString(fichier, contenu);
+        } catch (IOException e) {
+            throw new StorageException("Impossible d'écrire le fichier", e);
+        }
+    }
+
+    @Override
+    public List<Livre> charger() throws StorageException {
+        if (!Files.exists(fichier)) {
+            return List.of();
+        }
+        try {
+            return Files.readAllLines(fichier).stream()
+                    .filter(line -> !line.isBlank())
+                    .map(line -> line.split(";"))
+                    .map(parts -> new Livre(parts[0], parts[1], parts[2], java.time.LocalDate.parse(parts[3])))
+                    .toList();
+        } catch (IOException e) {
+            throw new StorageException("Lecture du fichier impossible", e);
+        }
+    }
+}

--- a/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/MemoryStorage.java
+++ b/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/MemoryStorage.java
@@ -1,0 +1,22 @@
+package com.biblio.storage;
+
+import com.biblio.core.Livre;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class MemoryStorage implements CatalogueStorage {
+
+    private final List<Livre> livres = new ArrayList<>();
+
+    @Override
+    public void sauvegarder(List<Livre> livres) {
+        this.livres.clear();
+        this.livres.addAll(livres);
+    }
+
+    @Override
+    public List<Livre> charger() {
+        return List.copyOf(livres);
+    }
+}

--- a/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/RemoteSynchronizer.java
+++ b/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/RemoteSynchronizer.java
@@ -1,0 +1,41 @@
+package com.biblio.storage;
+
+import com.biblio.core.Livre;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+public final class RemoteSynchronizer {
+
+    private final HttpClient client;
+    private final URI endpoint;
+
+    public RemoteSynchronizer(HttpClient client, URI endpoint) {
+        this.client = client;
+        this.endpoint = endpoint;
+    }
+
+    public void envoyer(List<Livre> livres) throws StorageException {
+        String body = livres.stream()
+                .map(Livre::titre)
+                .reduce("", (acc, titre) -> acc + titre + "\n");
+        HttpRequest request = HttpRequest.newBuilder(endpoint)
+                .timeout(Duration.ofSeconds(2))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 400) {
+                throw new StorageException("Synchronisation distante échouée : " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new StorageException("Erreur lors de l'appel distant", e);
+        }
+    }
+}

--- a/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/StorageException.java
+++ b/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/StorageException.java
@@ -1,0 +1,11 @@
+package com.biblio.storage;
+
+public class StorageException extends Exception {
+    public StorageException(String message) {
+        super(message);
+    }
+
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/StubHttpClient.java
+++ b/exercices/projets-integres/correction/TP1/storage/src/main/java/com/biblio/storage/StubHttpClient.java
@@ -1,0 +1,127 @@
+package com.biblio.storage;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+
+public final class StubHttpClient extends HttpClient {
+
+    @Override
+    public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+        return new SimpleResponse<>(request, (T) "SYNC OK");
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        return CompletableFuture.completedFuture(new SimpleResponse<>(request, (T) "SYNC OK"));
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> responseBodyHandler,
+                                                            HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        return sendAsync(request, responseBodyHandler);
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        return Redirect.NEVER;
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return Optional.empty();
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        return null;
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        return null;
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Version version() {
+        return Version.HTTP_1_1;
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        return Optional.empty();
+    }
+
+    private record SimpleResponse<T>(HttpRequest request, T body) implements HttpResponse<T> {
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public HttpRequest request() {
+            return request;
+        }
+
+        @Override
+        public Optional<HttpResponse<T>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (a, b) -> true);
+        }
+
+        @Override
+        public T body() {
+            return body;
+        }
+
+        @Override
+        public Optional<SSLSession> sslSession() {
+            return Optional.empty();
+        }
+
+        @Override
+        public URI uri() {
+            return request.uri();
+        }
+
+        @Override
+        public Version version() {
+            return Version.HTTP_1_1;
+        }
+    }
+}

--- a/exercices/projets-integres/correction/TP1/storage/src/main/java/module-info.java
+++ b/exercices/projets-integres/correction/TP1/storage/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module com.biblio.storage {
+    requires com.biblio.core;
+    requires java.net.http;
+    exports com.biblio.storage;
+}


### PR DESCRIPTION
## Summary
- add runnable Maven correction projects for the fundamentals TPs covering sensor simulation and text utilities
- implement SOLID-oriented POO examples, collection pipelines, and robust IO persistence corrections for their respective TPs
- deliver functional-programming and modular multi-module solutions plus an integrated library CLI project

## Testing
- `mvn -q -f exercices/fondamentaux/correction/TP1/pom.xml package`
- `mvn -q -f exercices/fondamentaux/correction/TP2/pom.xml package`
- `mvn -q -f exercices/fonctionnel-moderne/correction/TP2/pom.xml package`
- `mvn -q -f exercices/projets-integres/correction/TP1/pom.xml package`


------
https://chatgpt.com/codex/tasks/task_b_68e2df32b8c4832aaaf52a364f52b274