### PR TITLE
Add Java 8 POJO Kickstarter dataset and enrich stream TP

### DIFF
--- a/exercices/fonctionnel-moderne/tp-streams.md
+++ b/exercices/fonctionnel-moderne/tp-streams.md
@@ -1,0 +1,124 @@
+# TP : Explorer l'API Stream de Java avec Kickstarter
+
+## Objectifs pédagogiques
+- Manipuler des flux (`Stream`) sur des collections riches.
+- Définir et combiner des `Predicate`, `Function`, `Consumer`, `Supplier` et `Comparator`.
+- Utiliser les opérations intermédiaires et terminales des streams (`map`, `filter`, `sorted`, `distinct`, `flatMap`, `peek`, etc.).
+- Mettre en œuvre les collecteurs (`Collectors`) pour agréger, partitionner et grouper des données.
+- Concevoir un mini-pipeline de traitement fonctionnel lisible, testable et réutilisable.
+
+## Mise en place
+1. Ouvrez le dossier [`kickstarter`](../../kickstarter) qui contient un jeu de données orienté « crowdfunding ».
+2. Si vous travaillez en Java 8, utilisez la variante [`kickstarter-java8`](../../kickstarter-java8) et son package `com.example.kickstarter.simple`.
+3. Ajoutez le package approprié à votre projet (Maven/Gradle/IDEA/Eclipse). Les classes sont prêtes à l'emploi.
+4. Créez une classe de tests (JUnit) ou une classe `main` dédiée (`KickstarterStreamPlayground`) pour réaliser les exercices.
+5. Dans vos solutions, privilégiez les expressions lambda plutôt que les classes anonymes, sauf mention contraire.
+6. Adaptez les références de méthodes (`Project::title` vs `Project::getTitle`) selon la version des classes que vous utilisez.
+
+## Rappel du modèle de données
+- `Project` : campagne Kickstarter (catégorie, pays, dates de lancement/fin, montants, tags, récompenses...).
+- `Backer` : personne qui soutient des projets (pays, intérêts, budget annuel, statut pro).
+- `Reward` : palier de récompense (titre, minimum, stock limité, livraison estimée).
+- `Pledge` : contribution d'un backer à un projet (montant, date, récompense choisie).
+- `KickstarterData` : fournit des collections immuables pré-remplies et des méthodes utilitaires pour créer des flux.
+
+> 💡 Lisez le JavaDoc de chaque classe et explorez les données fournies pour mieux comprendre les attributs disponibles.
+
+## Travaux pratiques
+
+### 1. Premiers pas avec les flux
+- Écrire un stream qui renvoie les titres des 5 projets qui se terminent le plus rapidement.
+- Utiliser un `Comparator` composé (par `Comparator.comparing`) puis `map(Project::title)`.
+- Ajouter un `peek` pour logger l'identifiant des projets (via un `Consumer<Project>` dédié).
+- Variante : afficher également le pays formaté via `KickstarterData.countryDisplayName` en utilisant `map` puis `forEach`.
+- Extra : ré-écrire l'exercice avec `Stream.iterate` pour simuler un flux infini puis `limit`.
+
+### 2. Prédicats réutilisables
+- Créer une classe `ProjectPredicates` contenant des méthodes retournant des `Predicate<Project>` (ex. : `isFunded()`, `isTrending()`, `belongsToCategory(String)`).
+- Mettre en pratique : filtrer les projets financés à plus de 110 % dans la catégorie *Design*.
+- Écrire un test paramétré qui combine les prédicats avec `and` / `or`.
+- Bonus : proposer un prédicat `launchedBetween(LocalDate, LocalDate)` réutilisable dans plusieurs tests.
+- Challenge : écrire un prédicat configurable via builder (ex. `new ProjectFilter().withMinFunding(150).locatedIn("US")`).
+
+### 3. Fonctions de transformation
+- Construire une `Function<Project, Optional<Reward>>` qui renvoie la récompense la plus accessible (`min` sur `minimumPledge`).
+- À partir de cette fonction, produire la liste des titres des récompenses d'entrée de gamme.
+- Bonus : utilisez `flatMap(Optional::stream)` pour éliminer les projets sans récompense.
+- Variante : exposer la fonction sous forme de `UnaryOperator<Project>` qui ajuste les montants (`map` sur une copie immuable).
+- Challenge : écrire une `Function<Project, Map<String, Object>>` pour sérialiser un projet en représentation JSON-friendly.
+
+### 4. Consumers et Supplier
+- Écrire un `Consumer<Pledge>` qui affiche un reçu formaté (utiliser `String.format`).
+- Créer un `Supplier<Stream<Pledge>>` basé sur `KickstarterData.streamPledges()` permettant de ré-exécuter plusieurs traitements indépendants sans dupliquer le code d'accès aux données.
+- Mettre en place deux traitements :
+  1. Montant total investi par pays des backers.
+  2. Classement des trois projets les plus soutenus par des backers professionnels.
+- Extra : brancher un `Consumer<Project>` qui alimente un logger ou un buffer mémoire pour générer un rapport.
+- Challenge : mettre en place un `Supplier<Double>` qui calcule paresseusement le budget moyen des backers par pays.
+
+### 5. Collectors avancés
+- Grouper les projets par catégorie (`Collectors.groupingBy`) et calculer :
+  - le nombre de projets,
+  - le taux de financement moyen (pledged/goal).
+- Partitionner les backers selon leur statut (`Collectors.partitioningBy(Backer::isProfessional)`).
+- Créer une carte triée (`TreeMap`) qui classe les projets par mois de lancement (`YearMonth`) et par montant total collecté (descending).
+- Extra : créer un `Collector` personnalisé qui construit une `String` multi-ligne décrivant chaque catégorie.
+- Challenge : implémenter un `Collector` multi-niveaux qui groupe par pays puis par catégorie avec des `LinkedHashMap` pour conserver l'ordre d'insertion.
+
+### 6. Pipelines complets
+- Construire un pipeline qui enchaîne :
+  1. Sélection des projets financés (`Predicate`).
+  2. Transformation en résumé (`Function<Project, ProjectSummary>` que vous définissez).
+  3. Tri par pourcentage de financement.
+  4. Collecte dans une `LinkedHashMap<String, Double>` (titre → pourcentage) en conservant l'ordre.
+- Implémenter `ProjectSummary` comme un `record`.
+- Prévoir un test qui valide à minima le top 3 attendu (précision ±0,01).
+- Variante : créer un pipeline équivalent qui retourne un `DoubleStream` et utilise `summaryStatistics`.
+- Challenge : exposer ce pipeline comme une `Function<Stream<Project>, Stream<ProjectSummary>>` et chaîner plusieurs fonctions via `andThen`.
+
+### 7. Réduction, statistiques et optionnel
+- Calculer la médiane des montants de promesse (`Pledge.amount()`). (Astuce : trier puis utiliser `skip`/`limit`).
+- Utiliser `Collectors.summarizingDouble` pour produire des statistiques descriptives par catégorie.
+- Écrire une méthode qui renvoie le `Optional<Project>` correspondant au projet ayant reçu une promesse un 1er janvier.
+- Extra : créer un calcul de variance et d'écart-type à l'aide d'une réduction personnalisée.
+- Challenge : implémenter une recherche dichotomique sur un `DoubleStream` obtenu via `mapToDouble` pour trouver un seuil de rentabilité.
+
+### 8. Bonus créatifs
+- Implémenter une pipeline réutilisable (`Function<Stream<Project>, Stream<Project>>`) qui applique un ensemble de filtres dynamiques.
+- Utiliser un `Predicate` construit à partir d'un fichier de configuration (parsing d'un `Properties`).
+- Expérimenter les `Collector` personnalisés : écrivez un collector qui construit un histogramme (Map plage de montants → nombre de promesses).
+- Extra : relier vos streams à une API tierce (CSV, JSON) pour exporter un rapport final.
+- Challenge : écrire un `Spliterator` personnalisé pour itérer sur les `Pledge` par fenêtre glissante.
+
+### 9. Exercices sur les parallélisations contrôlées
+- Comparer un traitement séquentiel et un traitement parallèle (`parallelStream`) sur le calcul du montant total investi.
+- Mettre en place un `ForkJoinPool` personnalisé pour maîtriser le niveau de parallélisme.
+- Explorer les problématiques de thread-safety : collectez les résultats dans une structure mutable non synchronisée puis dans une structure thread-safe.
+
+### 10. Tests et validation
+- Écrire des tests de non-régression sur vos pipelines via `@MethodSource` (JUnit 5).
+- Ajouter un test de performance (JMH ou micro-bench maison) pour comparer deux implémentations d'un même calcul.
+- Mettre en place des assertions sur les `Optional` (`assertTrue(optional.isPresent())`) et sur les statistiques calculées.
+
+### 11. Exercices full FP
+- Recréez une version `Project` immutable manuellement (constructeur privé + builder) et adaptez vos streams en conséquence.
+- Utilisez `Stream#reduce` pour implémenter un mini moteur de règles fonctionnelles appliqué aux `Backer`.
+- Composez plusieurs `Function` et `Predicate` via `compose`/`andThen` pour créer un pipeline déclaratif unique.
+
+### 12. Défis de synthèse
+- Réalisez une commande `TopRewards` qui combine `Project`, `Reward` et `Pledge` pour afficher les récompenses les plus populaires.
+- Créez un tableau de bord texte avec `StringBuilder` + `forEachOrdered` résumant : projets financés, montants moyens, top backers.
+- Imaginez un traitement complet : ingestion (`Supplier`), filtrage (`Predicate`), transformation (`Function`), agrégation (`Collector`) et rendu (`Consumer`). Documentez chaque étape.
+
+## Livrables attendus
+- Le code source de vos solutions (tests ou classe `main`).
+- Un court rapport Markdown décrivant les choix réalisés, les points de blocage et les pistes d'amélioration.
+- (Bonus) Un graphique ou tableau synthétique produit via un export CSV/JSON et traité avec un outil externe.
+
+## Conseils
+- Commencez simple : utilisez `Stream` directement, puis factorisez vos prédicats/fonctions.
+- Pensez à la lisibilité : nommez vos lambdas ou extraire des méthodes lorsque le pipeline devient long.
+- Utilisez les tests unitaires pour figer des comportements attendus et éviter les régressions.
+- Documentez les cas limites (collections vides, montants nulls) et le comportement choisi.
+
+Bon TP ! 🚀

--- a/kickstarter-java8/README.md
+++ b/kickstarter-java8/README.md
@@ -1,0 +1,18 @@
+# Dataset Kickstarter (Java 8)
+
+Cette variante du module `kickstarter` fournit les mêmes données d'exemple mais avec des classes Java 8 "classiques"
+(plutôt que des `record`). Les collections exposées sont immuables et prêtes à l'emploi pour les exercices sur les streams.
+
+## Contenu
+- Package `com.example.kickstarter.simple` contenant des POJO (`Project`, `Backer`, `Reward`, `Pledge`, `Category`).
+- Classe utilitaire `KickstarterData` offrant des listes et des flux sur les données.
+- API volontairement minimaliste : constructeurs, getters, `equals/hashCode` et quelques méthodes métiers (`fundingProgress`,
+  `isFinished`).
+
+## Utilisation
+1. Ajoutez le dossier `kickstarter-java8/src/main/java` à votre projet ou IDE.
+2. Importez le package `com.example.kickstarter.simple`.
+3. Travaillez avec les collections immuables fournies ou utilisez les méthodes `streamProjects`, `streamBackers` et
+   `streamPledges`.
+
+> 💡 Cette version est compatible avec Java 8 et facilite l'intégration dans des projets ne supportant pas encore les `record`.

--- a/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Backer.java
+++ b/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Backer.java
@@ -1,0 +1,96 @@
+package com.example.kickstarter.simple;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Représente un contributeur de projets Kickstarter (version Java 8 sans record).
+ */
+public final class Backer {
+
+    private final UUID id;
+    private final String name;
+    private final String country;
+    private final Set<String> interests;
+    private final double annualBudget;
+    private final boolean professional;
+
+    public Backer(UUID id,
+                  String name,
+                  String country,
+                  Set<String> interests,
+                  double annualBudget,
+                  boolean professional) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.name = Objects.requireNonNull(name, "name");
+        this.country = Objects.requireNonNull(country, "country");
+        Set<String> copy = new LinkedHashSet<>(Objects.requireNonNull(interests, "interests"));
+        this.interests = Collections.unmodifiableSet(copy);
+        if (annualBudget < 0) {
+            throw new IllegalArgumentException("annualBudget doit être positif");
+        }
+        this.annualBudget = annualBudget;
+        this.professional = professional;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public Set<String> getInterests() {
+        return interests;
+    }
+
+    public double getAnnualBudget() {
+        return annualBudget;
+    }
+
+    public boolean isProfessional() {
+        return professional;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Backer)) {
+            return false;
+        }
+        Backer backer = (Backer) o;
+        return professional == backer.professional
+                && Double.compare(backer.annualBudget, annualBudget) == 0
+                && id.equals(backer.id)
+                && name.equals(backer.name)
+                && country.equals(backer.country)
+                && interests.equals(backer.interests);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, country, interests, annualBudget, professional);
+    }
+
+    @Override
+    public String toString() {
+        return "Backer{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", country='" + country + '\'' +
+                ", interests=" + interests +
+                ", annualBudget=" + annualBudget +
+                ", professional=" + professional +
+                '}';
+    }
+}

--- a/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Category.java
+++ b/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Category.java
@@ -1,0 +1,25 @@
+package com.example.kickstarter.simple;
+
+/**
+ * Catégories simplifiées pour les projets Kickstarter.
+ */
+public enum Category {
+    ART("Art"),
+    DESIGN("Design"),
+    FILM("Film & Video"),
+    FOOD("Food"),
+    GAMES("Games"),
+    MUSIC("Music"),
+    PUBLISHING("Publishing"),
+    TECHNOLOGY("Technology");
+
+    private final String displayName;
+
+    Category(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/kickstarter-java8/src/main/java/com/example/kickstarter/simple/KickstarterData.java
+++ b/kickstarter-java8/src/main/java/com/example/kickstarter/simple/KickstarterData.java
@@ -1,0 +1,300 @@
+package com.example.kickstarter.simple;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Jeu de données statique destiné aux exercices sur les streams (compatible Java 8).
+ */
+public final class KickstarterData {
+
+    public static final List<Project> PROJECTS;
+    public static final List<Backer> BACKERS;
+    public static final List<Pledge> PLEDGES;
+    public static final Map<UUID, Project> PROJECT_BY_ID;
+    public static final Map<UUID, Backer> BACKER_BY_ID;
+
+    static {
+        List<Project> projects = new ArrayList<>();
+
+        Project modularDesk = new Project(
+                UUID.fromString("0c8b2d8b-15c0-4ef0-a54a-f1c2de26f4da"),
+                "Modular Desk System",
+                Category.DESIGN,
+                "US",
+                "Portland",
+                85_000,
+                123_500,
+                LocalDate.of(2023, Month.SEPTEMBER, 12),
+                LocalDate.of(2023, Month.OCTOBER, 27),
+                "Studio Timber",
+                tags("workspace", "sustainable", "productivity"),
+                rewards(
+                        new Reward("Sticker pack", 15, false, LocalDate.of(2024, Month.JANUARY, 15), "Stickers recyclés"),
+                        new Reward("Desk starter kit", 99, false, LocalDate.of(2024, Month.FEBRUARY, 28), "Modules de base"),
+                        new Reward("Complete setup", 259, true, LocalDate.of(2024, Month.APRIL, 30), "Configuration complète")
+                )
+        );
+        projects.add(modularDesk);
+
+        Project indieAdventure = new Project(
+                UUID.fromString("fdfb6eb2-7a3a-4cf0-b7b8-8f2f3a4006f7"),
+                "Indie Adventure Game",
+                Category.GAMES,
+                "CA",
+                "Vancouver",
+                65_000,
+                72_450,
+                LocalDate.of(2024, Month.JANUARY, 8),
+                LocalDate.of(2024, Month.MARCH, 2),
+                "Pixel Sprouts",
+                tags("metroidvania", "pixel-art", "soundtrack"),
+                rewards(
+                        new Reward("Digital copy", 20, false, LocalDate.of(2024, Month.JUNE, 1), "Jeu + fond d'écran"),
+                        new Reward("Collector edition", 80, true, LocalDate.of(2024, Month.JULY, 15), "OST + artbook"),
+                        new Reward("Design workshop", 150, true, LocalDate.of(2024, Month.AUGUST, 10), "Session live avec l'équipe")
+                )
+        );
+        projects.add(indieAdventure);
+
+        Project fermentationKit = new Project(
+                UUID.fromString("11e6a132-0fb4-4b7e-a89a-2bce845fc98f"),
+                "Artisanal Fermentation Kit",
+                Category.FOOD,
+                "FR",
+                "Lyon",
+                30_000,
+                44_280,
+                LocalDate.of(2023, Month.NOVEMBER, 4),
+                LocalDate.of(2023, Month.DECEMBER, 20),
+                "Ferments & Co",
+                tags("kombucha", "zero-waste", "starter"),
+                rewards(
+                        new Reward("Recettes PDF", 12, false, LocalDate.of(2024, Month.JANUARY, 5), "12 recettes exclusives"),
+                        new Reward("Kit découverte", 39, false, LocalDate.of(2024, Month.FEBRUARY, 1), "Materiel + cultures"),
+                        new Reward("Masterclass", 95, true, LocalDate.of(2024, Month.MARCH, 18), "Atelier en présentiel")
+                )
+        );
+        projects.add(fermentationKit);
+
+        Project synthwaveVinyl = new Project(
+                UUID.fromString("3d53a2e4-6115-4c68-baf0-6de97c1ae499"),
+                "Synthwave Vinyl Collection",
+                Category.MUSIC,
+                "DE",
+                "Berlin",
+                42_000,
+                39_120,
+                LocalDate.of(2024, Month.FEBRUARY, 20),
+                LocalDate.of(2024, Month.APRIL, 5),
+                "Neon Pulse",
+                tags("vinyl", "retro", "limited"),
+                rewards(
+                        new Reward("Digital album", 18, false, LocalDate.of(2024, Month.APRIL, 20), "Album numérique"),
+                        new Reward("Vinyl standard", 35, false, LocalDate.of(2024, Month.JUNE, 12), "Vinyl simple"),
+                        new Reward("Vinyl deluxe", 65, true, LocalDate.of(2024, Month.JULY, 8), "Vinyl double avec art prints")
+                )
+        );
+        projects.add(synthwaveVinyl);
+
+        Project ecoBackpack = new Project(
+                UUID.fromString("dd8b1dcd-71d4-4f61-8090-046d220c0e4f"),
+                "Eco-smart Backpack",
+                Category.TECHNOLOGY,
+                "US",
+                "San Francisco",
+                110_000,
+                158_900,
+                LocalDate.of(2023, Month.OCTOBER, 2),
+                LocalDate.of(2023, Month.NOVEMBER, 18),
+                "NovaGear Labs",
+                tags("smart", "solar", "travel"),
+                rewards(
+                        new Reward("Early backer", 119, true, LocalDate.of(2024, Month.JUNE, 10), "Sac à prix réduit"),
+                        new Reward("Standard pack", 149, false, LocalDate.of(2024, Month.JULY, 1), "Couleur au choix"),
+                        new Reward("Duo pack", 279, true, LocalDate.of(2024, Month.AUGUST, 5), "Deux sacs + accessoires")
+                )
+        );
+        projects.add(ecoBackpack);
+
+        Project graphicAnthology = new Project(
+                UUID.fromString("985a7685-3ff6-4d55-8cd6-1c7392e961a5"),
+                "Graphic Novel Anthology",
+                Category.PUBLISHING,
+                "UK",
+                "Bristol",
+                24_000,
+                21_650,
+                LocalDate.of(2024, Month.JANUARY, 28),
+                LocalDate.of(2024, Month.MARCH, 10),
+                "Ink&Bones",
+                tags("comics", "anthology", "fantasy"),
+                rewards(
+                        new Reward("Digital anthology", 14, false, LocalDate.of(2024, Month.MAY, 12), "PDF + wallpapers"),
+                        new Reward("Hardcover", 32, false, LocalDate.of(2024, Month.JUNE, 30), "Livre relié"),
+                        new Reward("Art print bundle", 55, true, LocalDate.of(2024, Month.JULY, 20), "Set de 5 prints")
+                )
+        );
+        projects.add(graphicAnthology);
+
+        Project shortFilm = new Project(
+                UUID.fromString("8f02cf67-8676-43f0-a974-8d9f29c5f1f0"),
+                "Neo-Noir Short Film",
+                Category.FILM,
+                "US",
+                "Chicago",
+                55_000,
+                61_780,
+                LocalDate.of(2023, Month.DECEMBER, 1),
+                LocalDate.of(2024, Month.JANUARY, 20),
+                "Lensflare Studio",
+                tags("cinema", "noir", "soundtrack"),
+                rewards(
+                        new Reward("Digital premiere", 20, false, LocalDate.of(2024, Month.MAY, 1), "Lien de streaming"),
+                        new Reward("Behind the scenes", 45, false, LocalDate.of(2024, Month.MAY, 20), "Documentaire"),
+                        new Reward("Set visit", 180, true, LocalDate.of(2024, Month.JUNE, 10), "Invitation sur le tournage")
+                )
+        );
+        projects.add(shortFilm);
+
+        Project museumExperience = new Project(
+                UUID.fromString("f63417d5-6630-4db1-a1a1-5f4c96d7b271"),
+                "Interactive Museum Experience",
+                Category.ART,
+                "NL",
+                "Amsterdam",
+                75_000,
+                88_420,
+                LocalDate.of(2024, Month.FEBRUARY, 5),
+                LocalDate.of(2024, Month.MARCH, 25),
+                "Immersive Collective",
+                tags("immersive", "education", "family"),
+                rewards(
+                        new Reward("Day pass", 22, false, LocalDate.of(2024, Month.SEPTEMBER, 1), "Entrée + audio guide"),
+                        new Reward("Family pack", 60, false, LocalDate.of(2024, Month.SEPTEMBER, 10), "4 entrées"),
+                        new Reward("Patron evening", 140, true, LocalDate.of(2024, Month.SEPTEMBER, 20), "Soirée privée")
+                )
+        );
+        projects.add(museumExperience);
+
+        PROJECTS = Collections.unmodifiableList(projects);
+        PROJECT_BY_ID = Collections.unmodifiableMap(PROJECTS.stream()
+                .collect(Collectors.toMap(Project::getId, Function.identity())));
+
+        List<Backer> backers = Arrays.asList(
+                new Backer(UUID.fromString("4b386082-24ab-4330-8cd5-55da743c2d78"), "Alicia Gomez", "ES", tags("design", "food", "travel"), 1_200, false),
+                new Backer(UUID.fromString("fc8f1ed6-3795-4e5d-b8a3-680cf17d4f9f"), "Noah Patel", "CA", tags("games", "technology", "music"), 2_500, true),
+                new Backer(UUID.fromString("1d6d6c39-d7f2-4d79-ae6d-7ae7b70bf3aa"), "Sofia Martins", "PT", tags("art", "film", "education"), 900, false),
+                new Backer(UUID.fromString("7e6bba4f-83b4-4f76-b112-1a27636cbb38"), "Daniel Weber", "DE", tags("music", "design", "technology"), 1_800, true),
+                new Backer(UUID.fromString("06df1c47-80e1-4603-83b7-7a2a664cc7cb"), "Chloe Martin", "FR", tags("food", "sustainability", "art"), 1_100, false),
+                new Backer(UUID.fromString("6c6f9975-15b2-4a34-9d2b-47b28a1b3c53"), "Ethan Johnson", "US", tags("film", "photography", "design"), 3_600, true),
+                new Backer(UUID.fromString("51a0fc39-76f9-4974-9f22-8688f050fde7"), "Mira Gupta", "IN", tags("technology", "education", "games"), 1_400, false)
+        );
+        BACKERS = Collections.unmodifiableList(new ArrayList<>(backers));
+        BACKER_BY_ID = Collections.unmodifiableMap(BACKERS.stream()
+                .collect(Collectors.toMap(Backer::getId, Function.identity())));
+
+        List<Pledge> pledges = Arrays.asList(
+                new Pledge(UUID.fromString("ba7dd5f4-2593-485b-bfb8-59b65513e4c2"), modularDesk.getId(), BACKERS.get(0).getId(), 99,
+                        LocalDateTime.of(2023, Month.SEPTEMBER, 15, 9, 24), Optional.of(modularDesk.getRewards().get(1))),
+                new Pledge(UUID.fromString("f3b86a12-8500-4d5f-b95b-cf56cf0fe7af"), modularDesk.getId(), BACKERS.get(5).getId(), 279,
+                        LocalDateTime.of(2023, Month.SEPTEMBER, 16, 16, 42), Optional.of(modularDesk.getRewards().get(2))),
+                new Pledge(UUID.fromString("f6e8a254-f7d2-47ab-9e6d-7b3c1ad89266"), ecoBackpack.getId(), BACKERS.get(1).getId(), 279,
+                        LocalDateTime.of(2023, Month.OCTOBER, 3, 12, 10), Optional.of(ecoBackpack.getRewards().get(2))),
+                new Pledge(UUID.fromString("2b6b1ea6-708b-4ad4-98dd-5041c9e0b56d"), ecoBackpack.getId(), BACKERS.get(3).getId(), 149,
+                        LocalDateTime.of(2023, Month.OCTOBER, 4, 8, 5), Optional.of(ecoBackpack.getRewards().get(1))),
+                new Pledge(UUID.fromString("785f256e-8f44-45cd-90da-89d4bde5a3c6"), ecoBackpack.getId(), BACKERS.get(6).getId(), 119,
+                        LocalDateTime.of(2023, Month.OCTOBER, 6, 20, 18), Optional.of(ecoBackpack.getRewards().get(0))),
+                new Pledge(UUID.fromString("c8f4c2d4-b9cf-44a2-af59-2f6c621408e4"), indieAdventure.getId(), BACKERS.get(1).getId(), 150,
+                        LocalDateTime.of(2024, Month.JANUARY, 9, 10, 45), Optional.of(indieAdventure.getRewards().get(2))),
+                new Pledge(UUID.fromString("0a2b6cdd-bb74-4a7f-9121-4a2d6f6ef9e0"), indieAdventure.getId(), BACKERS.get(2).getId(), 20,
+                        LocalDateTime.of(2024, Month.JANUARY, 10, 14, 33), Optional.of(indieAdventure.getRewards().get(0))),
+                new Pledge(UUID.fromString("3a8bcf2e-d78a-4d72-a42f-c8f1b742f60e"), indieAdventure.getId(), BACKERS.get(4).getId(), 80,
+                        LocalDateTime.of(2024, Month.JANUARY, 11, 21, 7), Optional.of(indieAdventure.getRewards().get(1))),
+                new Pledge(UUID.fromString("9f2d5fd0-63b6-4e5e-845e-8cc2a7c7670d"), fermentationKit.getId(), BACKERS.get(4).getId(), 39,
+                        LocalDateTime.of(2023, Month.NOVEMBER, 6, 9, 2), Optional.of(fermentationKit.getRewards().get(1))),
+                new Pledge(UUID.fromString("64abf9ae-4341-494f-a501-ffcd04a17b1c"), fermentationKit.getId(), BACKERS.get(0).getId(), 95,
+                        LocalDateTime.of(2023, Month.NOVEMBER, 7, 17, 20), Optional.of(fermentationKit.getRewards().get(2))),
+                new Pledge(UUID.fromString("4168ce02-29b1-47b9-a0db-7f4fe6a2416e"), fermentationKit.getId(), BACKERS.get(6).getId(), 12,
+                        LocalDateTime.of(2023, Month.NOVEMBER, 8, 13, 55), Optional.of(fermentationKit.getRewards().get(0))),
+                new Pledge(UUID.fromString("889663e3-e7e7-48c2-bdd6-939b4fba8cb5"), synthwaveVinyl.getId(), BACKERS.get(3).getId(), 65,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 22, 11, 0), Optional.of(synthwaveVinyl.getRewards().get(2))),
+                new Pledge(UUID.fromString("f9c36a62-633c-46b0-b6fc-0ea8d1f5f55f"), synthwaveVinyl.getId(), BACKERS.get(5).getId(), 35,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 23, 18, 12), Optional.of(synthwaveVinyl.getRewards().get(1))),
+                new Pledge(UUID.fromString("0e215acd-542f-4f3f-8aa2-cc91f88eb8ba"), shortFilm.getId(), BACKERS.get(2).getId(), 45,
+                        LocalDateTime.of(2023, Month.DECEMBER, 3, 19, 26), Optional.of(shortFilm.getRewards().get(1))),
+                new Pledge(UUID.fromString("3e45b272-701f-4cdf-90fb-f46fb4aa2b28"), shortFilm.getId(), BACKERS.get(5).getId(), 180,
+                        LocalDateTime.of(2023, Month.DECEMBER, 4, 8, 41), Optional.of(shortFilm.getRewards().get(2))),
+                new Pledge(UUID.fromString("b6d0461f-314c-4b92-8e74-bae7c79e2d8f"), shortFilm.getId(), BACKERS.get(0).getId(), 20,
+                        LocalDateTime.of(2023, Month.DECEMBER, 6, 22, 5), Optional.of(shortFilm.getRewards().get(0))),
+                new Pledge(UUID.fromString("d1c8120c-7a3f-438f-9d68-1f34b4ece2e1"), museumExperience.getId(), BACKERS.get(6).getId(), 140,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 7, 15, 12), Optional.of(museumExperience.getRewards().get(2))),
+                new Pledge(UUID.fromString("a7f56cf3-600f-4cb0-9bd2-5f4da112b34f"), museumExperience.getId(), BACKERS.get(2).getId(), 60,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 8, 10, 34), Optional.of(museumExperience.getRewards().get(1))),
+                new Pledge(UUID.fromString("ad4cf558-2d6a-4450-8019-b8dd64126618"), museumExperience.getId(), BACKERS.get(1).getId(), 22,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 9, 9, 15), Optional.of(museumExperience.getRewards().get(0)))
+        );
+        PLEDGES = Collections.unmodifiableList(new ArrayList<>(pledges));
+    }
+
+    private KickstarterData() {
+        throw new AssertionError("No instances");
+    }
+
+    public static Stream<Project> streamProjects() {
+        return PROJECTS.stream();
+    }
+
+    public static Stream<Backer> streamBackers() {
+        return BACKERS.stream();
+    }
+
+    public static Stream<Pledge> streamPledges() {
+        return PLEDGES.stream();
+    }
+
+    public static Project requireProject(UUID id) {
+        Project project = PROJECT_BY_ID.get(id);
+        if (project == null) {
+            throw new IllegalArgumentException("Projet introuvable : " + id);
+        }
+        return project;
+    }
+
+    public static Backer requireBacker(UUID id) {
+        Backer backer = BACKER_BY_ID.get(id);
+        if (backer == null) {
+            throw new IllegalArgumentException("Backer introuvable : " + id);
+        }
+        return backer;
+    }
+
+    public static String countryDisplayName(String isoCode) {
+        Locale locale = new Locale("", Objects.requireNonNull(isoCode, "isoCode"));
+        return locale.getDisplayCountry(Locale.FRENCH);
+    }
+
+    private static Set<String> tags(String... values) {
+        LinkedHashSet<String> set = new LinkedHashSet<>(Arrays.asList(values));
+        return Collections.unmodifiableSet(set);
+    }
+
+    private static List<Reward> rewards(Reward... rewards) {
+        return Collections.unmodifiableList(Arrays.asList(rewards));
+    }
+}

--- a/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Pledge.java
+++ b/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Pledge.java
@@ -1,0 +1,94 @@
+package com.example.kickstarter.simple;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Contribution d'un backer à un projet.
+ */
+public final class Pledge {
+
+    private final UUID id;
+    private final UUID projectId;
+    private final UUID backerId;
+    private final double amount;
+    private final LocalDateTime pledgedAt;
+    private final Optional<Reward> reward;
+
+    public Pledge(UUID id,
+                  UUID projectId,
+                  UUID backerId,
+                  double amount,
+                  LocalDateTime pledgedAt,
+                  Optional<Reward> reward) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.projectId = Objects.requireNonNull(projectId, "projectId");
+        this.backerId = Objects.requireNonNull(backerId, "backerId");
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount doit être strictement positif");
+        }
+        this.amount = amount;
+        this.pledgedAt = Objects.requireNonNull(pledgedAt, "pledgedAt");
+        this.reward = Objects.requireNonNull(reward, "reward");
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getProjectId() {
+        return projectId;
+    }
+
+    public UUID getBackerId() {
+        return backerId;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public LocalDateTime getPledgedAt() {
+        return pledgedAt;
+    }
+
+    public Optional<Reward> getReward() {
+        return reward;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Pledge)) {
+            return false;
+        }
+        Pledge pledge = (Pledge) o;
+        return Double.compare(pledge.amount, amount) == 0
+                && id.equals(pledge.id)
+                && projectId.equals(pledge.projectId)
+                && backerId.equals(pledge.backerId)
+                && pledgedAt.equals(pledge.pledgedAt)
+                && reward.equals(pledge.reward);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, projectId, backerId, amount, pledgedAt, reward);
+    }
+
+    @Override
+    public String toString() {
+        return "Pledge{" +
+                "id=" + id +
+                ", projectId=" + projectId +
+                ", backerId=" + backerId +
+                ", amount=" + amount +
+                ", pledgedAt=" + pledgedAt +
+                ", reward=" + reward +
+                '}';
+    }
+}

--- a/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Project.java
+++ b/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Project.java
@@ -1,0 +1,166 @@
+package com.example.kickstarter.simple;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Projet Kickstarter en version Java 8.
+ */
+public final class Project {
+
+    private final UUID id;
+    private final String title;
+    private final Category category;
+    private final String country;
+    private final String city;
+    private final double goalAmount;
+    private final double pledgedAmount;
+    private final LocalDate launchDate;
+    private final LocalDate deadline;
+    private final String owner;
+    private final Set<String> tags;
+    private final List<Reward> rewards;
+
+    public Project(UUID id,
+                   String title,
+                   Category category,
+                   String country,
+                   String city,
+                   double goalAmount,
+                   double pledgedAmount,
+                   LocalDate launchDate,
+                   LocalDate deadline,
+                   String owner,
+                   Set<String> tags,
+                   List<Reward> rewards) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.title = Objects.requireNonNull(title, "title");
+        this.category = Objects.requireNonNull(category, "category");
+        this.country = Objects.requireNonNull(country, "country");
+        this.city = Objects.requireNonNull(city, "city");
+        if (goalAmount <= 0) {
+            throw new IllegalArgumentException("goalAmount doit être strictement positif");
+        }
+        this.goalAmount = goalAmount;
+        if (pledgedAmount < 0) {
+            throw new IllegalArgumentException("pledgedAmount ne peut pas être négatif");
+        }
+        this.pledgedAmount = pledgedAmount;
+        this.launchDate = Objects.requireNonNull(launchDate, "launchDate");
+        this.deadline = Objects.requireNonNull(deadline, "deadline");
+        this.owner = Objects.requireNonNull(owner, "owner");
+        Set<String> tagsCopy = new LinkedHashSet<>(Objects.requireNonNull(tags, "tags"));
+        this.tags = Collections.unmodifiableSet(tagsCopy);
+        List<Reward> rewardCopy = new ArrayList<>(Objects.requireNonNull(rewards, "rewards"));
+        this.rewards = Collections.unmodifiableList(rewardCopy);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public double getGoalAmount() {
+        return goalAmount;
+    }
+
+    public double getPledgedAmount() {
+        return pledgedAmount;
+    }
+
+    public LocalDate getLaunchDate() {
+        return launchDate;
+    }
+
+    public LocalDate getDeadline() {
+        return deadline;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    public List<Reward> getRewards() {
+        return rewards;
+    }
+
+    public double fundingProgress() {
+        return pledgedAmount / goalAmount * 100.0;
+    }
+
+    public boolean isFinished(LocalDate referenceDate) {
+        Objects.requireNonNull(referenceDate, "referenceDate");
+        return !deadline.isAfter(referenceDate);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Project)) {
+            return false;
+        }
+        Project project = (Project) o;
+        return Double.compare(project.goalAmount, goalAmount) == 0
+                && Double.compare(project.pledgedAmount, pledgedAmount) == 0
+                && id.equals(project.id)
+                && title.equals(project.title)
+                && category == project.category
+                && country.equals(project.country)
+                && city.equals(project.city)
+                && launchDate.equals(project.launchDate)
+                && deadline.equals(project.deadline)
+                && owner.equals(project.owner)
+                && tags.equals(project.tags)
+                && rewards.equals(project.rewards);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, category, country, city, goalAmount, pledgedAmount, launchDate, deadline, owner, tags, rewards);
+    }
+
+    @Override
+    public String toString() {
+        return "Project{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", category=" + category +
+                ", country='" + country + '\'' +
+                ", city='" + city + '\'' +
+                ", goalAmount=" + goalAmount +
+                ", pledgedAmount=" + pledgedAmount +
+                ", launchDate=" + launchDate +
+                ", deadline=" + deadline +
+                ", owner='" + owner + '\'' +
+                ", tags=" + tags +
+                ", rewards=" + rewards +
+                '}';
+    }
+}

--- a/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Reward.java
+++ b/kickstarter-java8/src/main/java/com/example/kickstarter/simple/Reward.java
@@ -1,0 +1,83 @@
+package com.example.kickstarter.simple;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * Niveau de récompense proposé par un projet Kickstarter.
+ */
+public final class Reward {
+
+    private final String title;
+    private final double minimumPledge;
+    private final boolean limited;
+    private final LocalDate estimatedDelivery;
+    private final String description;
+
+    public Reward(String title,
+                  double minimumPledge,
+                  boolean limited,
+                  LocalDate estimatedDelivery,
+                  String description) {
+        this.title = Objects.requireNonNull(title, "title");
+        if (minimumPledge < 0) {
+            throw new IllegalArgumentException("minimumPledge doit être positif");
+        }
+        this.minimumPledge = minimumPledge;
+        this.limited = limited;
+        this.estimatedDelivery = Objects.requireNonNull(estimatedDelivery, "estimatedDelivery");
+        this.description = Objects.requireNonNull(description, "description");
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public double getMinimumPledge() {
+        return minimumPledge;
+    }
+
+    public boolean isLimited() {
+        return limited;
+    }
+
+    public LocalDate getEstimatedDelivery() {
+        return estimatedDelivery;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Reward)) {
+            return false;
+        }
+        Reward reward = (Reward) o;
+        return limited == reward.limited
+                && Double.compare(reward.minimumPledge, minimumPledge) == 0
+                && title.equals(reward.title)
+                && estimatedDelivery.equals(reward.estimatedDelivery)
+                && description.equals(reward.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, minimumPledge, limited, estimatedDelivery, description);
+    }
+
+    @Override
+    public String toString() {
+        return "Reward{" +
+                "title='" + title + '\'' +
+                ", minimumPledge=" + minimumPledge +
+                ", limited=" + limited +
+                ", estimatedDelivery=" + estimatedDelivery +
+                ", description='" + description + '\'' +
+                '}';
+    }
+}

--- a/kickstarter/README.md
+++ b/kickstarter/README.md
@@ -1,0 +1,28 @@
+# Données Kickstarter pour exercices Streams
+
+Ce module fournit un jeu de données Java prêt à l'emploi pour expérimenter l'API Stream.
+
+## Contenu
+- `Category` : enum des catégories disponibles.
+- `Reward` : record décrivant un palier de récompense.
+- `Project` : record décrivant une campagne Kickstarter et exposant des aides (`fundingProgress`, `isFinished`).
+- `Backer` : record représentant un contributeur.
+- `Pledge` : record représentant une promesse de contribution.
+- `KickstarterData` : agrégateur contenant les collections immuables (`PROJECTS`, `BACKERS`, `PLEDGES`) et plusieurs méthodes utilitaires.
+
+## Utilisation rapide
+```java
+var projects = KickstarterData.PROJECTS;
+var fundedDesignProjects = KickstarterData.streamProjects()
+        .filter(project -> project.category() == Category.DESIGN)
+        .filter(project -> project.fundingProgress() >= 100)
+        .toList();
+```
+
+Les collections exposées sont immuables ; si vous avez besoin de structures modifiables, créez une copie :
+
+```java
+var mutableCopy = new ArrayList<>(KickstarterData.PROJECTS);
+```
+
+Bon prototypage !

--- a/kickstarter/src/main/java/com/example/kickstarter/Backer.java
+++ b/kickstarter/src/main/java/com/example/kickstarter/Backer.java
@@ -1,0 +1,27 @@
+package com.example.kickstarter;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Représente un contributeur de projets Kickstarter.
+ */
+public record Backer(
+        UUID id,
+        String name,
+        String country,
+        Set<String> interests,
+        double annualBudget,
+        boolean professional
+) {
+    public Backer {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(country, "country");
+        interests = Set.copyOf(Objects.requireNonNull(interests, "interests"));
+        if (annualBudget < 0) {
+            throw new IllegalArgumentException("annualBudget doit être positif");
+        }
+    }
+}

--- a/kickstarter/src/main/java/com/example/kickstarter/Category.java
+++ b/kickstarter/src/main/java/com/example/kickstarter/Category.java
@@ -1,0 +1,28 @@
+package com.example.kickstarter;
+
+/**
+ * Enumeration des principales catégories de projets présentes dans l'échantillon.
+ */
+public enum Category {
+    ART("Art"),
+    DESIGN("Design"),
+    FILM("Film & Video"),
+    FOOD("Food"),
+    GAMES("Games"),
+    MUSIC("Music"),
+    PUBLISHING("Publishing"),
+    TECHNOLOGY("Technology");
+
+    private final String displayName;
+
+    Category(String displayName) {
+        this.displayName = displayName;
+    }
+
+    /**
+     * @return nom "marketing" lisible de la catégorie.
+     */
+    public String displayName() {
+        return displayName;
+    }
+}

--- a/kickstarter/src/main/java/com/example/kickstarter/KickstarterData.java
+++ b/kickstarter/src/main/java/com/example/kickstarter/KickstarterData.java
@@ -1,0 +1,295 @@
+package com.example.kickstarter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Jeu de données statique destiné aux exercices sur les streams.
+ */
+public final class KickstarterData {
+
+    public static final List<Project> PROJECTS;
+    public static final List<Backer> BACKERS;
+    public static final List<Pledge> PLEDGES;
+    public static final Map<UUID, Project> PROJECT_BY_ID;
+    public static final Map<UUID, Backer> BACKER_BY_ID;
+
+    static {
+        var projects = new ArrayList<Project>();
+
+        var modularDesk = new Project(
+                UUID.fromString("0c8b2d8b-15c0-4ef0-a54a-f1c2de26f4da"),
+                "Modular Desk System",
+                Category.DESIGN,
+                "US",
+                "Portland",
+                85_000,
+                123_500,
+                LocalDate.of(2023, Month.SEPTEMBER, 12),
+                LocalDate.of(2023, Month.OCTOBER, 27),
+                "Studio Timber",
+                Set.of("workspace", "sustainable", "productivity"),
+                List.of(
+                        new Reward("Sticker pack", 15, false, LocalDate.of(2024, Month.JANUARY, 15), "Stickers recyclés"),
+                        new Reward("Desk starter kit", 99, false, LocalDate.of(2024, Month.FEBRUARY, 28), "Modules de base"),
+                        new Reward("Complete setup", 259, true, LocalDate.of(2024, Month.APRIL, 30), "Configuration complète")
+                )
+        );
+        projects.add(modularDesk);
+
+        var indieAdventure = new Project(
+                UUID.fromString("fdfb6eb2-7a3a-4cf0-b7b8-8f2f3a4006f7"),
+                "Indie Adventure Game",
+                Category.GAMES,
+                "CA",
+                "Vancouver",
+                65_000,
+                72_450,
+                LocalDate.of(2024, Month.JANUARY, 8),
+                LocalDate.of(2024, Month.MARCH, 2),
+                "Pixel Sprouts",
+                Set.of("metroidvania", "pixel-art", "soundtrack"),
+                List.of(
+                        new Reward("Digital copy", 20, false, LocalDate.of(2024, Month.JUNE, 1), "Jeu + fond d'écran"),
+                        new Reward("Collector edition", 80, true, LocalDate.of(2024, Month.JULY, 15), "OST + artbook"),
+                        new Reward("Design workshop", 150, true, LocalDate.of(2024, Month.AUGUST, 10), "Session live avec l'équipe")
+                )
+        );
+        projects.add(indieAdventure);
+
+        var fermentationKit = new Project(
+                UUID.fromString("11e6a132-0fb4-4b7e-a89a-2bce845fc98f"),
+                "Artisanal Fermentation Kit",
+                Category.FOOD,
+                "FR",
+                "Lyon",
+                30_000,
+                44_280,
+                LocalDate.of(2023, Month.NOVEMBER, 4),
+                LocalDate.of(2023, Month.DECEMBER, 20),
+                "Ferments & Co",
+                Set.of("kombucha", "zero-waste", "starter"),
+                List.of(
+                        new Reward("Recettes PDF", 12, false, LocalDate.of(2024, Month.JANUARY, 5), "12 recettes exclusives"),
+                        new Reward("Kit découverte", 39, false, LocalDate.of(2024, Month.FEBRUARY, 1), "Materiel + cultures"),
+                        new Reward("Masterclass", 95, true, LocalDate.of(2024, Month.MARCH, 18), "Atelier en présentiel")
+                )
+        );
+        projects.add(fermentationKit);
+
+        var synthwaveVinyl = new Project(
+                UUID.fromString("3d53a2e4-6115-4c68-baf0-6de97c1ae499"),
+                "Synthwave Vinyl Collection",
+                Category.MUSIC,
+                "DE",
+                "Berlin",
+                42_000,
+                39_120,
+                LocalDate.of(2024, Month.FEBRUARY, 20),
+                LocalDate.of(2024, Month.APRIL, 5),
+                "Neon Pulse",
+                Set.of("vinyl", "retro", "limited"),
+                List.of(
+                        new Reward("Digital album", 18, false, LocalDate.of(2024, Month.APRIL, 20), "Album numérique"),
+                        new Reward("Vinyl standard", 35, false, LocalDate.of(2024, Month.JUNE, 12), "Vinyl simple"),
+                        new Reward("Vinyl deluxe", 65, true, LocalDate.of(2024, Month.JULY, 8), "Vinyl double avec art prints")
+                )
+        );
+        projects.add(synthwaveVinyl);
+
+        var ecoBackpack = new Project(
+                UUID.fromString("dd8b1dcd-71d4-4f61-8090-046d220c0e4f"),
+                "Eco-smart Backpack",
+                Category.TECHNOLOGY,
+                "US",
+                "San Francisco",
+                110_000,
+                158_900,
+                LocalDate.of(2023, Month.OCTOBER, 2),
+                LocalDate.of(2023, Month.NOVEMBER, 18),
+                "NovaGear Labs",
+                Set.of("smart", "solar", "travel"),
+                List.of(
+                        new Reward("Early backer", 119, true, LocalDate.of(2024, Month.JUNE, 10), "Sac à prix réduit"),
+                        new Reward("Standard pack", 149, false, LocalDate.of(2024, Month.JULY, 1), "Couleur au choix"),
+                        new Reward("Duo pack", 279, true, LocalDate.of(2024, Month.AUGUST, 5), "Deux sacs + accessoires")
+                )
+        );
+        projects.add(ecoBackpack);
+
+        var graphicAnthology = new Project(
+                UUID.fromString("985a7685-3ff6-4d55-8cd6-1c7392e961a5"),
+                "Graphic Novel Anthology",
+                Category.PUBLISHING,
+                "UK",
+                "Bristol",
+                24_000,
+                21_650,
+                LocalDate.of(2024, Month.JANUARY, 28),
+                LocalDate.of(2024, Month.MARCH, 10),
+                "Ink&Bones",
+                Set.of("comics", "anthology", "fantasy"),
+                List.of(
+                        new Reward("Digital anthology", 14, false, LocalDate.of(2024, Month.MAY, 12), "PDF + wallpapers"),
+                        new Reward("Hardcover", 32, false, LocalDate.of(2024, Month.JUNE, 30), "Livre relié"),
+                        new Reward("Art print bundle", 55, true, LocalDate.of(2024, Month.JULY, 20), "Set de 5 prints")
+                )
+        );
+        projects.add(graphicAnthology);
+
+        var shortFilm = new Project(
+                UUID.fromString("8f02cf67-8676-43f0-a974-8d9f29c5f1f0"),
+                "Neo-Noir Short Film",
+                Category.FILM,
+                "US",
+                "Chicago",
+                55_000,
+                61_780,
+                LocalDate.of(2023, Month.DECEMBER, 1),
+                LocalDate.of(2024, Month.JANUARY, 20),
+                "Lensflare Studio",
+                Set.of("cinema", "noir", "soundtrack"),
+                List.of(
+                        new Reward("Digital premiere", 20, false, LocalDate.of(2024, Month.MAY, 1), "Lien de streaming"),
+                        new Reward("Behind the scenes", 45, false, LocalDate.of(2024, Month.MAY, 20), "Documentaire"),
+                        new Reward("Set visit", 180, true, LocalDate.of(2024, Month.JUNE, 10), "Invitation sur le tournage")
+                )
+        );
+        projects.add(shortFilm);
+
+        var museumExperience = new Project(
+                UUID.fromString("f63417d5-6630-4db1-a1a1-5f4c96d7b271"),
+                "Interactive Museum Experience",
+                Category.ART,
+                "NL",
+                "Amsterdam",
+                75_000,
+                88_420,
+                LocalDate.of(2024, Month.FEBRUARY, 5),
+                LocalDate.of(2024, Month.MARCH, 25),
+                "Immersive Collective",
+                Set.of("immersive", "education", "family"),
+                List.of(
+                        new Reward("Day pass", 22, false, LocalDate.of(2024, Month.SEPTEMBER, 1), "Entrée + audio guide"),
+                        new Reward("Family pack", 60, false, LocalDate.of(2024, Month.SEPTEMBER, 10), "4 entrées"),
+                        new Reward("Patron evening", 140, true, LocalDate.of(2024, Month.SEPTEMBER, 20), "Soirée privée")
+                )
+        );
+        projects.add(museumExperience);
+
+        PROJECTS = List.copyOf(projects);
+        PROJECT_BY_ID = PROJECTS.stream().collect(toMap(Project::id, Function.identity()));
+
+        BACKERS = List.of(
+                new Backer(UUID.fromString("4b386082-24ab-4330-8cd5-55da743c2d78"), "Alicia Gomez", "ES", Set.of("design", "food", "travel"), 1_200, false),
+                new Backer(UUID.fromString("fc8f1ed6-3795-4e5d-b8a3-680cf17d4f9f"), "Noah Patel", "CA", Set.of("games", "technology", "music"), 2_500, true),
+                new Backer(UUID.fromString("1d6d6c39-d7f2-4d79-ae6d-7ae7b70bf3aa"), "Sofia Martins", "PT", Set.of("art", "film", "education"), 900, false),
+                new Backer(UUID.fromString("7e6bba4f-83b4-4f76-b112-1a27636cbb38"), "Daniel Weber", "DE", Set.of("music", "design", "technology"), 1_800, true),
+                new Backer(UUID.fromString("06df1c47-80e1-4603-83b7-7a2a664cc7cb"), "Chloe Martin", "FR", Set.of("food", "sustainability", "art"), 1_100, false),
+                new Backer(UUID.fromString("6c6f9975-15b2-4a34-9d2b-47b28a1b3c53"), "Ethan Johnson", "US", Set.of("film", "photography", "design"), 3_600, true),
+                new Backer(UUID.fromString("51a0fc39-76f9-4974-9f22-8688f050fde7"), "Mira Gupta", "IN", Set.of("technology", "education", "games"), 1_400, false)
+        );
+        BACKER_BY_ID = BACKERS.stream().collect(toMap(Backer::id, Function.identity()));
+
+        PLEDGES = List.of(
+                new Pledge(UUID.fromString("ba7dd5f4-2593-485b-bfb8-59b65513e4c2"), modularDesk.id(), BACKERS.get(0).id(), 99,
+                        LocalDateTime.of(2023, Month.SEPTEMBER, 15, 9, 24), Optional.of(modularDesk.rewards().get(1))),
+                new Pledge(UUID.fromString("f3b86a12-8500-4d5f-b95b-cf56cf0fe7af"), modularDesk.id(), BACKERS.get(5).id(), 279,
+                        LocalDateTime.of(2023, Month.SEPTEMBER, 16, 16, 42), Optional.of(modularDesk.rewards().get(2))),
+                new Pledge(UUID.fromString("f6e8a254-f7d2-47ab-9e6d-7b3c1ad89266"), ecoBackpack.id(), BACKERS.get(1).id(), 279,
+                        LocalDateTime.of(2023, Month.OCTOBER, 3, 12, 10), Optional.of(ecoBackpack.rewards().get(2))),
+                new Pledge(UUID.fromString("2b6b1ea6-708b-4ad4-98dd-5041c9e0b56d"), ecoBackpack.id(), BACKERS.get(3).id(), 149,
+                        LocalDateTime.of(2023, Month.OCTOBER, 4, 8, 5), Optional.of(ecoBackpack.rewards().get(1))),
+                new Pledge(UUID.fromString("785f256e-8f44-45cd-90da-89d4bde5a3c6"), ecoBackpack.id(), BACKERS.get(6).id(), 119,
+                        LocalDateTime.of(2023, Month.OCTOBER, 6, 20, 18), Optional.of(ecoBackpack.rewards().get(0))),
+                new Pledge(UUID.fromString("c8f4c2d4-b9cf-44a2-af59-2f6c621408e4"), indieAdventure.id(), BACKERS.get(1).id(), 150,
+                        LocalDateTime.of(2024, Month.JANUARY, 9, 10, 45), Optional.of(indieAdventure.rewards().get(2))),
+                new Pledge(UUID.fromString("0a2b6cdd-bb74-4a7f-9121-4a2d6f6ef9e0"), indieAdventure.id(), BACKERS.get(2).id(), 20,
+                        LocalDateTime.of(2024, Month.JANUARY, 10, 14, 33), Optional.of(indieAdventure.rewards().get(0))),
+                new Pledge(UUID.fromString("3a8bcf2e-d78a-4d72-a42f-c8f1b742f60e"), indieAdventure.id(), BACKERS.get(4).id(), 80,
+                        LocalDateTime.of(2024, Month.JANUARY, 11, 21, 7), Optional.of(indieAdventure.rewards().get(1))),
+                new Pledge(UUID.fromString("9f2d5fd0-63b6-4e5e-845e-8cc2a7c7670d"), fermentationKit.id(), BACKERS.get(4).id(), 39,
+                        LocalDateTime.of(2023, Month.NOVEMBER, 6, 9, 2), Optional.of(fermentationKit.rewards().get(1))),
+                new Pledge(UUID.fromString("64abf9ae-4341-494f-a501-ffcd04a17b1c"), fermentationKit.id(), BACKERS.get(0).id(), 95,
+                        LocalDateTime.of(2023, Month.NOVEMBER, 7, 17, 20), Optional.of(fermentationKit.rewards().get(2))),
+                new Pledge(UUID.fromString("4168ce02-29b1-47b9-a0db-7f4fe6a2416e"), fermentationKit.id(), BACKERS.get(6).id(), 12,
+                        LocalDateTime.of(2023, Month.NOVEMBER, 8, 13, 55), Optional.of(fermentationKit.rewards().get(0))),
+                new Pledge(UUID.fromString("889663e3-e7e7-48c2-bdd6-939b4fba8cb5"), synthwaveVinyl.id(), BACKERS.get(3).id(), 65,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 22, 11, 0), Optional.of(synthwaveVinyl.rewards().get(2))),
+                new Pledge(UUID.fromString("f9c36a62-633c-46b0-b6fc-0ea8d1f5f55f"), synthwaveVinyl.id(), BACKERS.get(5).id(), 35,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 23, 18, 12), Optional.of(synthwaveVinyl.rewards().get(1))),
+                new Pledge(UUID.fromString("0e215acd-542f-4f3f-8aa2-cc91f88eb8ba"), shortFilm.id(), BACKERS.get(2).id(), 45,
+                        LocalDateTime.of(2023, Month.DECEMBER, 3, 19, 26), Optional.of(shortFilm.rewards().get(1))),
+                new Pledge(UUID.fromString("3e45b272-701f-4cdf-90fb-f46fb4aa2b28"), shortFilm.id(), BACKERS.get(5).id(), 180,
+                        LocalDateTime.of(2023, Month.DECEMBER, 4, 8, 41), Optional.of(shortFilm.rewards().get(2))),
+                new Pledge(UUID.fromString("b6d0461f-314c-4b92-8e74-bae7c79e2d8f"), shortFilm.id(), BACKERS.get(0).id(), 20,
+                        LocalDateTime.of(2023, Month.DECEMBER, 6, 22, 5), Optional.of(shortFilm.rewards().get(0))),
+                new Pledge(UUID.fromString("d1c8120c-7a3f-438f-9d68-1f34b4ece2e1"), museumExperience.id(), BACKERS.get(6).id(), 140,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 7, 15, 12), Optional.of(museumExperience.rewards().get(2))),
+                new Pledge(UUID.fromString("a7f56cf3-600f-4cb0-9bd2-5f4da112b34f"), museumExperience.id(), BACKERS.get(2).id(), 60,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 8, 10, 34), Optional.of(museumExperience.rewards().get(1))),
+                new Pledge(UUID.fromString("ad4cf558-2d6a-4450-8019-b8dd64126618"), museumExperience.id(), BACKERS.get(1).id(), 22,
+                        LocalDateTime.of(2024, Month.FEBRUARY, 9, 9, 15), Optional.of(museumExperience.rewards().get(0)))
+        );
+    }
+
+    private KickstarterData() {
+        throw new AssertionError("No instances");
+    }
+
+    /**
+     * @return un flux réutilisable de projets.
+     */
+    public static Stream<Project> streamProjects() {
+        return PROJECTS.stream();
+    }
+
+    /**
+     * @return un flux réutilisable de backers.
+     */
+    public static Stream<Backer> streamBackers() {
+        return BACKERS.stream();
+    }
+
+    /**
+     * @return un flux réutilisable de promesses.
+     */
+    public static Stream<Pledge> streamPledges() {
+        return PLEDGES.stream();
+    }
+
+    /**
+     * Permet de récupérer un projet par son identifiant.
+     */
+    public static Project requireProject(UUID id) {
+        return Objects.requireNonNull(PROJECT_BY_ID.get(id), () -> "Projet introuvable : " + id);
+    }
+
+    /**
+     * Permet de récupérer un backer par son identifiant.
+     */
+    public static Backer requireBacker(UUID id) {
+        return Objects.requireNonNull(BACKER_BY_ID.get(id), () -> "Backer introuvable : " + id);
+    }
+
+    /**
+     * Utilitaire pratique pour internationaliser les pays sur deux lettres.
+     */
+    public static String countryDisplayName(String isoCode) {
+        var locale = new Locale("", Objects.requireNonNull(isoCode, "isoCode"));
+        return locale.getDisplayCountry(Locale.FRENCH);
+    }
+}

--- a/kickstarter/src/main/java/com/example/kickstarter/Pledge.java
+++ b/kickstarter/src/main/java/com/example/kickstarter/Pledge.java
@@ -1,0 +1,29 @@
+package com.example.kickstarter;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Contribution d'un backer à un projet.
+ */
+public record Pledge(
+        UUID id,
+        UUID projectId,
+        UUID backerId,
+        double amount,
+        LocalDateTime pledgedAt,
+        Optional<Reward> reward
+) {
+    public Pledge {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(projectId, "projectId");
+        Objects.requireNonNull(backerId, "backerId");
+        Objects.requireNonNull(pledgedAt, "pledgedAt");
+        reward = Objects.requireNonNullElse(reward, Optional.empty());
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount doit être strictement positif");
+        }
+    }
+}

--- a/kickstarter/src/main/java/com/example/kickstarter/Project.java
+++ b/kickstarter/src/main/java/com/example/kickstarter/Project.java
@@ -1,0 +1,59 @@
+package com.example.kickstarter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Projet Kickstarter avec des informations enrichies pour travailler sur les streams.
+ */
+public record Project(
+        UUID id,
+        String title,
+        Category category,
+        String country,
+        String city,
+        double goalAmount,
+        double pledgedAmount,
+        LocalDate launchDate,
+        LocalDate deadline,
+        String owner,
+        Set<String> tags,
+        List<Reward> rewards
+) {
+    public Project {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(category, "category");
+        Objects.requireNonNull(country, "country");
+        Objects.requireNonNull(city, "city");
+        Objects.requireNonNull(launchDate, "launchDate");
+        Objects.requireNonNull(deadline, "deadline");
+        Objects.requireNonNull(owner, "owner");
+        tags = Set.copyOf(Objects.requireNonNull(tags, "tags"));
+        rewards = List.copyOf(Objects.requireNonNull(rewards, "rewards"));
+        if (goalAmount <= 0) {
+            throw new IllegalArgumentException("goalAmount doit être strictement positif");
+        }
+        if (pledgedAmount < 0) {
+            throw new IllegalArgumentException("pledgedAmount ne peut pas être négatif");
+        }
+    }
+
+    /**
+     * @return pourcentage de financement (100 = objectif atteint).
+     */
+    public double fundingProgress() {
+        return pledgedAmount / goalAmount * 100.0;
+    }
+
+    /**
+     * @return true si la campagne est terminée (deadline passée).
+     */
+    public boolean isFinished(LocalDate referenceDate) {
+        return deadline.isBefore(Objects.requireNonNull(referenceDate, "referenceDate"))
+                || deadline.isEqual(referenceDate);
+    }
+}

--- a/kickstarter/src/main/java/com/example/kickstarter/Reward.java
+++ b/kickstarter/src/main/java/com/example/kickstarter/Reward.java
@@ -1,0 +1,24 @@
+package com.example.kickstarter;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * Représente une récompense proposée par un projet Kickstarter.
+ */
+public record Reward(
+        String title,
+        double minimumPledge,
+        boolean limited,
+        LocalDate estimatedDelivery,
+        String description
+) {
+    public Reward {
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(estimatedDelivery, "estimatedDelivery");
+        Objects.requireNonNull(description, "description");
+        if (minimumPledge < 0) {
+            throw new IllegalArgumentException("minimumPledge doit être positif");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Java 8 compatible version of the Kickstarter sample data using simple POJO classes
- document the new dataset module for quick adoption
- expand the stream TP with additional exercises, variants and advanced challenges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3a16b4cc0832a855450e89001468d