### PR TITLE
Add reactive and CompletableFuture concurrency workshops

### DIFF
--- a/modern-java-examples/java21-concurrency/README.md
+++ b/modern-java-examples/java21-concurrency/README.md
@@ -11,3 +11,25 @@
 var scope = new ScopedValuesDemo();
 scope.runInScope("req-42");
 ```
+
+## Atelier : pipeline urbain asynchrone
+
+Le package `com.example.java21.project` propose un mini-projet complet qui couvre :
+
+- l'orchestration d'appels distants avec `CompletableFuture` et des threads virtuels (`CompletableFutureWorkshop`),
+- l'utilisation de `ProcessHandle` pour observer et superviser des sous-processus,
+- la mise en place de flux réactifs (`SubmissionPublisher`, `Flow.Processor`) avec des tâches asynchrones (`ReactiveWorkshop`).
+
+### Lancer le pipeline de `CompletableFuture`
+
+```bash
+mvn -pl java21-concurrency -am exec:java -Dexec.mainClass=com.example.java21.project.CompletableFutureWorkshop
+```
+
+### Lancer la démo réactive
+
+```bash
+mvn -pl java21-concurrency -am exec:java -Dexec.mainClass=com.example.java21.project.ReactiveWorkshop
+```
+
+Chaque exemple journalise les threads utilisés, les métriques de performance et les événements réactifs afin de faciliter le debugging et l'optimisation.

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/ScopedValuesDemo.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/ScopedValuesDemo.java
@@ -10,7 +10,11 @@ public class ScopedValuesDemo {
     private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
 
     public String runInScope(String requestId) {
-        return ScopedValue.where(REQUEST_ID, requestId)
-                .call(() -> "Traitement pour " + REQUEST_ID.get());
+        try {
+            return ScopedValue.where(REQUEST_ID, requestId)
+                    .call(() -> "Traitement pour " + REQUEST_ID.get());
+        } catch (Exception e) {
+            throw new IllegalStateException("Impossible d'exécuter le traitement dans la portée", e);
+        }
     }
 }

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CityAlert.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CityAlert.java
@@ -1,0 +1,9 @@
+package com.example.java21.project;
+
+import java.time.Instant;
+
+/**
+ * Évènement envoyé via un flux réactif lorsque l'indice de confort dépasse un seuil.
+ */
+public record CityAlert(String city, double comfortIndex, Instant emittedAt, String source) {
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CityAlertSubscriber.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CityAlertSubscriber.java
@@ -1,0 +1,57 @@
+package com.example.java21.project;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Consommateur réactif qui permet également de diagnostiquer les débits en affichant
+ * le temps entre deux éléments.
+ */
+public final class CityAlertSubscriber implements Flow.Subscriber<CityAlert> {
+
+    private final AtomicInteger received = new AtomicInteger();
+    private final CountDownLatch completed = new CountDownLatch(1);
+    private Flow.Subscription subscription;
+    private Instant lastElementTime;
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        this.subscription = Objects.requireNonNull(subscription);
+        this.lastElementTime = Instant.now();
+        subscription.request(1);
+    }
+
+    @Override
+    public void onNext(CityAlert item) {
+        var now = Instant.now();
+        var delta = Duration.between(lastElementTime, now);
+        System.out.printf("[%s] Alerte #%d reçue en %d ms : %s (indice=%.2f)%n",
+                Thread.currentThread().getName(),
+                received.incrementAndGet(),
+                delta.toMillis(),
+                item.city(),
+                item.comfortIndex());
+        lastElementTime = now;
+        subscription.request(1);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        System.err.println("Flux réactif interrompu : " + throwable.getMessage());
+        completed.countDown();
+    }
+
+    @Override
+    public void onComplete() {
+        System.out.println("Flux réactif terminé.");
+        completed.countDown();
+    }
+
+    public void awaitCompletion() throws InterruptedException {
+        completed.await();
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CityReport.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CityReport.java
@@ -1,0 +1,7 @@
+package com.example.java21.project;
+
+/**
+ * Résultat agrégé de plusieurs tâches asynchrones.
+ */
+public record CityReport(String city, double comfortIndex, WeatherRecord weather, int trafficDelayMinutes) {
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/ComfortIndexProcessor.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/ComfortIndexProcessor.java
@@ -1,0 +1,55 @@
+package com.example.java21.project;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+
+/**
+ * Transforme des mesures en alertes lorsque l'indice de confort dépasse un seuil.
+ */
+public final class ComfortIndexProcessor extends SubmissionPublisher<CityAlert>
+        implements Flow.Processor<WeatherRecord, CityAlert> {
+
+    private final double threshold;
+    private final String source;
+    private Flow.Subscription subscription;
+
+    public ComfortIndexProcessor(double threshold, String source, Executor executor) {
+        super(executor, Flow.defaultBufferSize());
+        this.threshold = threshold;
+        this.source = Objects.requireNonNull(source);
+    }
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        this.subscription = Objects.requireNonNull(subscription);
+        subscription.request(1);
+    }
+
+    @Override
+    public void onNext(WeatherRecord item) {
+        var comfortIndex = computeComfortIndex(item);
+        if (comfortIndex >= threshold) {
+            submit(new CityAlert(item.city(), comfortIndex, Instant.now(), source));
+        }
+        subscription.request(1);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        closeExceptionally(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        close();
+    }
+
+    private double computeComfortIndex(WeatherRecord weather) {
+        double temperatureScore = 100 - Math.abs(22 - weather.temperatureCelsius()) * 3;
+        double humidityScore = 100 - Math.abs(50 - weather.humidityPercentage()) * 1.5;
+        return Math.max(0, (temperatureScore + humidityScore) / 2.0);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CompletableFutureWorkshop.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/CompletableFutureWorkshop.java
@@ -1,0 +1,151 @@
+package com.example.java21.project;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Atelier complet couvrant la gestion des {@link java.util.concurrent.CompletableFuture} et de
+ * {@link ProcessHandle} afin de démontrer les nouveautés introduites depuis Java&nbsp;9.
+ */
+public final class CompletableFutureWorkshop {
+
+    private final ExecutorService executor;
+    private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+    private CompletableFutureWorkshop(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            new CompletableFutureWorkshop(executor).run();
+        }
+    }
+
+    private void run() throws Exception {
+        log("Démarrage du pipeline d'analyse urbaine sur thread virtuel=%s".formatted(Thread.currentThread().isVirtual()));
+        var globalStart = Instant.now();
+        var cities = List.of("Paris", "Lyon", "Marseille", "Toulouse", "Bordeaux");
+
+        var weatherFuture = loadWeatherData(cities)
+                .orTimeout(1, TimeUnit.SECONDS) // Java 9 : détection d'un blocage
+                .exceptionally(ex -> {
+                    log("Les données météo ne sont pas disponibles : %s".formatted(ex.getMessage()));
+                    return List.of();
+                });
+
+        var trafficFuture = loadTrafficData(cities);
+
+        var combinedFuture = weatherFuture.thenCombineAsync(trafficFuture, this::mergeData, executor)
+                .thenApplyAsync(this::rankCities, executor)
+                .completeOnTimeout(List.of(), 2, TimeUnit.SECONDS);
+
+        var reports = combinedFuture.join();
+        reports.forEach(report ->
+                log("Ville %s → indice confort %.2f, retard trafic %d min"
+                        .formatted(report.city(), report.comfortIndex(), report.trafficDelayMinutes())));
+
+        monitorCurrentProcess();
+        launchReportExporterProcess();
+
+        var totalDuration = Duration.between(globalStart, Instant.now());
+        log("Pipeline complet exécuté en %d ms (threads utilisés=%d)".formatted(
+                totalDuration.toMillis(), threadMXBean.getThreadCount()));
+    }
+
+    private CompletableFuture<List<WeatherRecord>> loadWeatherData(List<String> cities) {
+        return CompletableFuture.supplyAsync(() -> {
+            var start = Instant.now();
+            sleep(250);
+            var random = ThreadLocalRandom.current();
+            var result = cities.stream()
+                    .map(city -> new WeatherRecord(
+                            city,
+                            15 + random.nextDouble(12),
+                            40 + random.nextDouble(50),
+                            Instant.now()))
+                    .toList();
+            log("Données météo récupérées en %d ms".formatted(Duration.between(start, Instant.now()).toMillis()));
+            return result;
+        }, executor);
+    }
+
+    private CompletableFuture<Map<String, Integer>> loadTrafficData(List<String> cities) {
+        return CompletableFuture.supplyAsync(() -> {
+            var start = Instant.now();
+            sleep(300);
+            var random = ThreadLocalRandom.current();
+            var result = cities.stream().collect(Collectors.toMap(city -> city, city -> 5 + random.nextInt(25)));
+            log("Données trafic récupérées en %d ms".formatted(Duration.between(start, Instant.now()).toMillis()));
+            return result;
+        }, executor);
+    }
+
+    private List<CityReport> mergeData(List<WeatherRecord> weather, Map<String, Integer> traffic) {
+        return weather.stream()
+                .map(record -> new CityReport(
+                        record.city(),
+                        computeComfortIndex(record, traffic.getOrDefault(record.city(), 0)),
+                        record,
+                        traffic.getOrDefault(record.city(), 0)))
+                .toList();
+    }
+
+    private List<CityReport> rankCities(List<CityReport> reports) {
+        return reports.stream()
+                .sorted((a, b) -> Double.compare(b.comfortIndex(), a.comfortIndex()))
+                .toList();
+    }
+
+    private double computeComfortIndex(WeatherRecord record, int trafficDelay) {
+        double weatherScore = 100 - Math.abs(22 - record.temperatureCelsius()) * 3;
+        double humidityScore = 100 - Math.abs(50 - record.humidityPercentage()) * 1.2;
+        double trafficPenalty = trafficDelay * 1.5;
+        return Math.max(0, (weatherScore + humidityScore) / 2 - trafficPenalty);
+    }
+
+    private void monitorCurrentProcess() {
+        var handle = ProcessHandle.current();
+        var info = handle.info();
+        var command = info.command().orElse("<java>");
+        var args = info.arguments()
+                .map(array -> String.join(" ", array))
+                .orElse("<aucun argument>");
+        log("Processus courant PID=%d, commande=%s, arguments=%s"
+                .formatted(handle.pid(), command, args));
+    }
+
+    private void launchReportExporterProcess() throws Exception {
+        var process = new ProcessBuilder("bash", "-lc", "echo Export vers CSV && sleep 1")
+                .start();
+        var handle = process.toHandle();
+        log("Sous-processus démarré PID=%d".formatted(handle.pid()));
+        handle.onExit().thenAccept(ph -> {
+            var exitCode = process.exitValue();
+            var cpu = ph.info().totalCpuDuration().map(Duration::toMillis).map(millis -> millis + " ms").orElse("n/d");
+            log("Sous-processus %d terminé (exit=%d, CPU=%s)".formatted(ph.pid(), exitCode, cpu));
+        }).join();
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void log(String message) {
+        System.out.printf("[%s][%s] %s%n", Instant.now(), Thread.currentThread().getName(), message);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/ReactiveWorkshop.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/ReactiveWorkshop.java
@@ -1,0 +1,56 @@
+package com.example.java21.project;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Application réactive combinant {@link CompletableFuture} et {@link Flow} (Reactive Streams).
+ */
+public final class ReactiveWorkshop {
+
+    public static void main(String[] args) throws Exception {
+        new ReactiveWorkshop().run();
+    }
+
+    private void run() throws Exception {
+        try (var publisherExecutor = Executors.newVirtualThreadPerTaskExecutor();
+             var publisher = new SubmissionPublisher<WeatherRecord>(publisherExecutor, Flow.defaultBufferSize());
+             var processor = new ComfortIndexProcessor(70, "comfort-pipeline", publisherExecutor)) {
+
+            var subscriber = new CityAlertSubscriber();
+            processor.subscribe(subscriber);
+            publisher.subscribe(processor);
+
+            var tasks = List.of(
+                    emitSensor("sensor-paris", publisher),
+                    emitSensor("sensor-lyon", publisher),
+                    emitSensor("sensor-bordeaux", publisher));
+
+            CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new)).join();
+            publisher.close();
+
+            subscriber.awaitCompletion();
+        }
+    }
+
+    private CompletableFuture<Void> emitSensor(String sensorId, SubmissionPublisher<WeatherRecord> publisher) {
+        var random = ThreadLocalRandom.current();
+        return CompletableFuture.runAsync(() -> {
+            for (int i = 0; i < 5; i++) {
+                CompletableFuture.runAsync(() -> publisher.submit(new WeatherRecord(
+                                sensorId.replace("sensor-", ""),
+                                16 + random.nextDouble(15),
+                                35 + random.nextDouble(40),
+                                Instant.now())),
+                        CompletableFuture.delayedExecutor(150 + random.nextInt(200), TimeUnit.MILLISECONDS))
+                        .join();
+            }
+        });
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/WeatherRecord.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/project/WeatherRecord.java
@@ -1,0 +1,12 @@
+package com.example.java21.project;
+
+import java.time.Instant;
+
+/**
+ * Représente une mesure météorologique réalisée par une sonde distante.
+ *
+ * <p>Les records introduits dans Java&nbsp;16 réduisent considérablement le code boilerplate
+ * tout en offrant une immutabilité pratique pour la programmation concurrente.</p>
+ */
+public record WeatherRecord(String city, double temperatureCelsius, double humidityPercentage, Instant measuredAt) {
+}


### PR DESCRIPTION
## Summary
- add a complete CompletableFuture-based pipeline demo that highlights Java 9+ APIs including ProcessHandle metrics
- provide a reactive stream workshop combining SubmissionPublisher, a custom Processor and async tasks
- document the new workshops and harden the existing ScopedValues demo against checked exceptions

## Testing
- `mvn -pl java21-concurrency -am -DskipTests compile`


------
https://chatgpt.com/codex/tasks/task_b_68e42d37db64832aa8d43ecb34da79e7