### PR TITLE
Modularize concurrency workshops into standalone demos

### DIFF
--- a/modern-java-examples/java21-concurrency/README.md
+++ b/modern-java-examples/java21-concurrency/README.md
@@ -11,3 +11,29 @@
 var scope = new ScopedValuesDemo();
 scope.runInScope("req-42");
 ```
+
+## Ateliers concurrentiels modulaires
+
+Le package `com.example.java21.workshop` isole chaque notion dans une classe autonome :
+
+| Concept | Classe principale | Points clés Java 9+ |
+| --- | --- | --- |
+| Introduction à `CompletableFuture` | `CompletableFutureIntroduction` | `orTimeout`, `completeOnTimeout`, threads virtuels |
+| Processus & `ProcessHandle` | `ProcessHandleExplorer` | Inspection, supervision et métriques CPU |
+| Parallélisation asynchrone | `AsyncTaskParallelizer` | `CompletableFuture.allOf`, temps limites, exécuteur virtuel |
+| TP `CompletableFuture` complet | `CityAnalyticsApp` | Agrégation de données, `ProcessHandle`, supervision de sous-processus |
+| Flux réactifs (`Flow`) | `ReactiveStreamsIntroduction` | `SubmissionPublisher`, backpressure manuel |
+| Debugging & optimisation | `ConcurrentDebuggingToolkit` | `ThreadMXBean`, timeouts, callbacks `whenComplete` |
+| TP réactif asynchrone | `ReactiveAlertApp` | Chaîne Publisher → Processor → Subscriber, `delayedExecutor` |
+
+Les classes utilitaires partagées (`WeatherRecord`, `CityReport`, `ComfortIndexProcessor`, etc.) résident dans `com.example.java21.workshop.support`.
+
+### Exécuter un atelier
+
+```bash
+mvn -pl java21-concurrency -am exec:java -Dexec.mainClass=com.example.java21.workshop.CompletableFutureIntroduction
+```
+
+Remplacez `CompletableFutureIntroduction` par la classe souhaitée (`ProcessHandleExplorer`, `AsyncTaskParallelizer`, etc.).
+
+Chaque exemple journalise les threads utilisés, les métriques de performance et les événements réactifs afin de faciliter le debugging et l'optimisation.

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/ScopedValuesDemo.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/ScopedValuesDemo.java
@@ -10,7 +10,11 @@ public class ScopedValuesDemo {
     private static final ScopedValue<String> REQUEST_ID = ScopedValue.newInstance();
 
     public String runInScope(String requestId) {
-        return ScopedValue.where(REQUEST_ID, requestId)
-                .call(() -> "Traitement pour " + REQUEST_ID.get());
+        try {
+            return ScopedValue.where(REQUEST_ID, requestId)
+                    .call(() -> "Traitement pour " + REQUEST_ID.get());
+        } catch (Exception e) {
+            throw new IllegalStateException("Impossible d'exécuter le traitement dans la portée", e);
+        }
     }
 }

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/AsyncTaskParallelizer.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/AsyncTaskParallelizer.java
@@ -1,0 +1,86 @@
+package com.example.java21.workshop;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Illustration de la parallélisation de tâches asynchrones avec {@link CompletableFuture}.
+ */
+public final class AsyncTaskParallelizer {
+
+    public static void main(String[] args) {
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            new AsyncTaskParallelizer(executor).run();
+        }
+    }
+
+    private final ExecutorService executor;
+
+    public AsyncTaskParallelizer(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    private void run() {
+        var start = Instant.now();
+        var warehouses = List.of("Paris", "Lyon", "Lille", "Nice");
+
+        var inventoryFuture = CompletableFuture.supplyAsync(() -> loadInventory(warehouses), executor);
+        var shippingFuture = CompletableFuture.supplyAsync(() -> loadShippingTimes(warehouses), executor);
+        var slaFuture = CompletableFuture.supplyAsync(this::loadSlaCommitments, executor);
+
+        var all = CompletableFuture.allOf(inventoryFuture, shippingFuture, slaFuture)
+                .orTimeout(2, TimeUnit.SECONDS)
+                .exceptionally(ex -> {
+                    log("Erreur globale : " + ex);
+                    return null;
+                });
+
+        all.join();
+
+        var decisions = inventoryFuture.join().entrySet().stream()
+                .map(entry -> "%s → stock=%d, livraison=%s, SLA=%s"
+                        .formatted(entry.getKey(),
+                                entry.getValue(),
+                                shippingFuture.join().get(entry.getKey()),
+                                slaFuture.join().getOrDefault(entry.getKey(), "standard")))
+                .toList();
+
+        decisions.forEach(decision -> log("Décision : " + decision));
+        log("Parallélisation terminée en %d ms".formatted(Duration.between(start, Instant.now()).toMillis()));
+    }
+
+    private Map<String, Integer> loadInventory(List<String> warehouses) {
+        simulateDelay(300);
+        return warehouses.stream().collect(Collectors.toMap(city -> city, city -> 50 + ThreadLocalRandom.current().nextInt(100)));
+    }
+
+    private Map<String, Duration> loadShippingTimes(List<String> warehouses) {
+        simulateDelay(200);
+        return warehouses.stream().collect(Collectors.toMap(city -> city, city -> Duration.ofHours(24 + ThreadLocalRandom.current().nextInt(48))));
+    }
+
+    private Map<String, String> loadSlaCommitments() {
+        simulateDelay(150);
+        return Map.of("Paris", "express", "Lyon", "prioritaire");
+    }
+
+    private void simulateDelay(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void log(String message) {
+        System.out.printf("[%s][%s] %s%n", Instant.now(), Thread.currentThread().getName(), message);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/CityAnalyticsApp.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/CityAnalyticsApp.java
@@ -1,0 +1,134 @@
+package com.example.java21.workshop;
+
+import com.example.java21.workshop.support.CityReport;
+import com.example.java21.workshop.support.WeatherRecord;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Travaux pratiques : application complète bâtie sur {@link CompletableFuture}.
+ */
+public final class CityAnalyticsApp {
+
+    private final ExecutorService executor;
+    private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+    public CityAnalyticsApp(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    public static void main(String[] args) throws Exception {
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            new CityAnalyticsApp(executor).run();
+        }
+    }
+
+    private void run() throws Exception {
+        var start = Instant.now();
+        var cities = List.of("Paris", "Lyon", "Marseille", "Toulouse", "Bordeaux");
+
+        var weatherFuture = loadWeatherData(cities)
+                .orTimeout(1, TimeUnit.SECONDS)
+                .exceptionally(ex -> {
+                    log("Données météo indisponibles : " + ex.getMessage());
+                    return List.of();
+                });
+
+        var trafficFuture = loadTrafficData(cities);
+
+        var rankedCities = weatherFuture
+                .thenCombineAsync(trafficFuture, this::mergeData, executor)
+                .thenApplyAsync(this::rankCities, executor)
+                .completeOnTimeout(List.of(), 2, TimeUnit.SECONDS)
+                .join();
+
+        rankedCities.forEach(report -> log("%s → indice %.2f, trafic %d min"
+                .formatted(report.city(), report.comfortIndex(), report.trafficDelayMinutes())));
+
+        monitorProcess();
+        launchExporter();
+
+        log("Temps total %d ms (threads actifs=%d)"
+                .formatted(Duration.between(start, Instant.now()).toMillis(), threadMXBean.getThreadCount()));
+    }
+
+    private CompletableFuture<List<WeatherRecord>> loadWeatherData(List<String> cities) {
+        return CompletableFuture.supplyAsync(() -> {
+            simulateDelay(250);
+            var random = ThreadLocalRandom.current();
+            return cities.stream()
+                    .map(city -> new WeatherRecord(city, 15 + random.nextDouble(12), 40 + random.nextDouble(50), Instant.now()))
+                    .toList();
+        }, executor);
+    }
+
+    private CompletableFuture<Map<String, Integer>> loadTrafficData(List<String> cities) {
+        return CompletableFuture.supplyAsync(() -> {
+            simulateDelay(300);
+            var random = ThreadLocalRandom.current();
+            return cities.stream().collect(Collectors.toMap(city -> city, city -> 5 + random.nextInt(25)));
+        }, executor);
+    }
+
+    private List<CityReport> mergeData(List<WeatherRecord> weather, Map<String, Integer> traffic) {
+        return weather.stream()
+                .map(record -> new CityReport(
+                        record.city(),
+                        computeComfortIndex(record, traffic.getOrDefault(record.city(), 0)),
+                        record,
+                        traffic.getOrDefault(record.city(), 0)))
+                .toList();
+    }
+
+    private List<CityReport> rankCities(List<CityReport> reports) {
+        return reports.stream()
+                .sorted((a, b) -> Double.compare(b.comfortIndex(), a.comfortIndex()))
+                .toList();
+    }
+
+    private double computeComfortIndex(WeatherRecord record, int trafficDelay) {
+        double weatherScore = 100 - Math.abs(22 - record.temperatureCelsius()) * 3;
+        double humidityScore = 100 - Math.abs(50 - record.humidityPercentage()) * 1.2;
+        double trafficPenalty = trafficDelay * 1.5;
+        return Math.max(0, (weatherScore + humidityScore) / 2 - trafficPenalty);
+    }
+
+    private void monitorProcess() {
+        var handle = ProcessHandle.current();
+        var info = handle.info();
+        log("Processus PID=%d, commande=%s"
+                .formatted(handle.pid(), info.command().orElse("<java>")));
+    }
+
+    private void launchExporter() throws Exception {
+        var process = new ProcessBuilder("bash", "-lc", "echo Export CSV && sleep 0.5").start();
+        var handle = process.toHandle();
+        handle.onExit().thenAccept(ph -> {
+            var cpu = ph.info().totalCpuDuration().map(Duration::toMillis).map(ms -> ms + " ms").orElse("n/d");
+            log("Export terminé (PID=%d, exit=%d, CPU=%s)".formatted(ph.pid(), process.exitValue(), cpu));
+        }).join();
+    }
+
+    private void simulateDelay(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void log(String message) {
+        System.out.printf("[%s][%s] %s%n", Instant.now(), Thread.currentThread().getName(), message);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/CompletableFutureIntroduction.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/CompletableFutureIntroduction.java
@@ -1,0 +1,77 @@
+package com.example.java21.workshop;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Introduction aux {@link CompletableFuture} exploitant les ajouts de Java 9+.
+ */
+public final class CompletableFutureIntroduction {
+
+    public static void main(String[] args) throws ExecutionException, InterruptedException {
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var start = Instant.now();
+
+            var temperatureFuture = CompletableFuture.supplyAsync(() -> loadTemperature("Paris"), executor)
+                    .orTimeout(500, TimeUnit.MILLISECONDS) // Java 9 : timeout direct
+                    .completeOnTimeout(18.0, 600, TimeUnit.MILLISECONDS); // Java 9 : valeur par défaut
+
+            var humidityFuture = CompletableFuture.supplyAsync(() -> loadHumidity("Paris"), executor)
+                    .orTimeout(500, TimeUnit.MILLISECONDS)
+                    .exceptionally(ex -> {
+                        log("Humidité indisponible : " + ex.getMessage());
+                        return 55.0;
+                    });
+
+            var comfortFuture = temperatureFuture.thenCombine(humidityFuture, CompletableFutureIntroduction::computeComfortIndex)
+                    .thenApply(index -> Math.round(index * 100.0) / 100.0)
+                    .whenComplete((value, error) -> {
+                        if (error != null) {
+                            log("Erreur finale : " + error.getMessage());
+                        } else {
+                            log("Indice de confort calculé : " + value);
+                        }
+                    });
+
+            log("Résultat → %.2f (calcul en %d ms)".formatted(
+                    comfortFuture.get(),
+                    Duration.between(start, Instant.now()).toMillis()));
+        }
+    }
+
+    private static double loadTemperature(String city) {
+        simulateDelay(250);
+        return 17 + ThreadLocalRandom.current().nextDouble(10);
+    }
+
+    private static double loadHumidity(String city) {
+        simulateDelay(350);
+        if (ThreadLocalRandom.current().nextInt(5) == 0) {
+            throw new IllegalStateException("Capteur d'humidité hors ligne");
+        }
+        return 40 + ThreadLocalRandom.current().nextDouble(20);
+    }
+
+    private static double computeComfortIndex(double temperature, double humidity) {
+        double tempScore = 100 - Math.abs(22 - temperature) * 3;
+        double humidityScore = 100 - Math.abs(50 - humidity) * 1.2;
+        return Math.max(0, (tempScore + humidityScore) / 2);
+    }
+
+    private static void simulateDelay(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void log(String message) {
+        System.out.printf("[%s][%s] %s%n", Instant.now(), Thread.currentThread().getName(), message);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ConcurrentDebuggingToolkit.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ConcurrentDebuggingToolkit.java
@@ -1,0 +1,64 @@
+package com.example.java21.workshop;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Outils de debugging et d'optimisation pour les applications concurrentes.
+ */
+public final class ConcurrentDebuggingToolkit {
+
+    public static void main(String[] args) {
+        var toolkit = new ConcurrentDebuggingToolkit();
+        toolkit.run();
+    }
+
+    private final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+    private void run() {
+        var start = Instant.now();
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var task = CompletableFuture.supplyAsync(() -> heavyComputation("A"), executor);
+            var diagnostic = task.thenApply(result -> result + " (optimisé)")
+                    .whenComplete((value, error) -> dumpThreadMetrics("calculation", error));
+
+            var fallback = task.orTimeout(750, TimeUnit.MILLISECONDS)
+                    .exceptionally(ex -> {
+                        dumpThreadMetrics("timeout", ex);
+                        return "Valeur par défaut";
+                    });
+
+            System.out.println("Résultat = " + diagnostic.thenCombine(fallback, (a, b) -> a + " / " + b).join());
+        }
+
+        System.out.printf("Durée totale = %d ms%n", Duration.between(start, Instant.now()).toMillis());
+    }
+
+    private String heavyComputation(String prefix) {
+        try {
+            Thread.sleep(300 + ThreadLocalRandom.current().nextInt(400));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return prefix + "-" + ThreadLocalRandom.current().nextInt(10_000);
+    }
+
+    private void dumpThreadMetrics(String stage, Throwable error) {
+        var threadCount = threadMXBean.getThreadCount();
+        var peak = threadMXBean.getPeakThreadCount();
+        var cpuTimeSupported = threadMXBean.isThreadCpuTimeSupported();
+        System.out.printf("[%s] threads=%d (pic=%d) CPUTime=%s erreur=%s%n",
+                stage,
+                threadCount,
+                peak,
+                cpuTimeSupported ? "activé" : "non supporté",
+                error != null ? error.getMessage() : "aucune");
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ProcessHandleExplorer.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ProcessHandleExplorer.java
@@ -1,0 +1,44 @@
+package com.example.java21.workshop;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+/**
+ * Démonstration des API {@link ProcessHandle} introduites à partir de Java 9.
+ */
+public final class ProcessHandleExplorer {
+
+    public static void main(String[] args) throws Exception {
+        var current = ProcessHandle.current();
+        var info = current.info();
+        System.out.printf("Processus courant → PID=%d, commande=%s%n", current.pid(), info.command().orElse("<java>"));
+
+        var snapshot = ProcessHandle.allProcesses()
+                .limit(5)
+                .map(handle -> "%d:%s".formatted(handle.pid(), handle.info().command().orElse("?")))
+                .collect(Collectors.joining(", "));
+        System.out.println("Processus visibles → " + snapshot);
+
+        var exporter = new ProcessBuilder("bash", "-lc", "echo 'rapport' && sleep 0.5")
+                .start();
+        var exporterHandle = exporter.toHandle();
+        System.out.printf("Sous-processus lancé PID=%d%n", exporterHandle.pid());
+
+        var startedAt = Instant.now();
+        exporterHandle.onExit().thenAccept(ph -> {
+            var duration = Duration.between(startedAt, Instant.now());
+            var cpu = ph.info().totalCpuDuration().map(Duration::toMillis).orElse(0L);
+            System.out.printf("Processus %d terminé en %d ms (CPU=%d ms, exit=%d)%n",
+                    ph.pid(), duration.toMillis(), cpu, exporter.exitValue());
+        }).join();
+
+        var mostRecent = ProcessHandle.allProcesses()
+                .filter(handle -> handle.info().startInstant().isPresent())
+                .max(Comparator.comparing(handle -> handle.info().startInstant().orElse(Instant.EPOCH)));
+
+        mostRecent.ifPresent(handle -> System.out.printf("Processus le plus récent → PID=%d, démarré à %s%n",
+                handle.pid(), handle.info().startInstant().orElse(Instant.EPOCH)));
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ReactiveAlertApp.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ReactiveAlertApp.java
@@ -1,0 +1,55 @@
+package com.example.java21.workshop;
+
+import com.example.java21.workshop.support.CityAlertSubscriber;
+import com.example.java21.workshop.support.ComfortIndexProcessor;
+import com.example.java21.workshop.support.WeatherRecord;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Travaux pratiques : application réactive avec tâches asynchrones et {@link java.util.concurrent.Flow}.
+ */
+public final class ReactiveAlertApp {
+
+    public static void main(String[] args) throws Exception {
+        new ReactiveAlertApp().run();
+    }
+
+    private void run() throws Exception {
+        try (var publisherExecutor = Executors.newVirtualThreadPerTaskExecutor();
+             var publisher = new SubmissionPublisher<WeatherRecord>(publisherExecutor, Flow.defaultBufferSize());
+             var processor = new ComfortIndexProcessor(70, "comfort-pipeline", publisherExecutor)) {
+
+            var subscriber = new CityAlertSubscriber();
+            processor.subscribe(subscriber);
+            publisher.subscribe(processor);
+
+            var tasks = List.of(
+                    emitSensor("Paris", publisher),
+                    emitSensor("Lyon", publisher),
+                    emitSensor("Bordeaux", publisher));
+
+            CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new)).join();
+            publisher.close();
+            subscriber.awaitCompletion();
+        }
+    }
+
+    private CompletableFuture<Void> emitSensor(String city, SubmissionPublisher<WeatherRecord> publisher) {
+        var random = ThreadLocalRandom.current();
+        return CompletableFuture.runAsync(() -> {
+            for (int i = 0; i < 5; i++) {
+                var record = new WeatherRecord(city, 16 + random.nextDouble(15), 35 + random.nextDouble(40), Instant.now());
+                CompletableFuture.runAsync(() -> publisher.submit(record),
+                        CompletableFuture.delayedExecutor(100 + random.nextInt(150), TimeUnit.MILLISECONDS)).join();
+            }
+        });
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ReactiveStreamsIntroduction.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/ReactiveStreamsIntroduction.java
@@ -1,0 +1,59 @@
+package com.example.java21.workshop;
+
+import com.example.java21.workshop.support.WeatherRecord;
+
+import java.time.Instant;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Introduction aux Reactive Streams via {@link Flow} et {@link SubmissionPublisher}.
+ */
+public final class ReactiveStreamsIntroduction {
+
+    public static void main(String[] args) throws Exception {
+        try (var publisher = new SubmissionPublisher<WeatherRecord>()) {
+            publisher.subscribe(new LoggingWeatherSubscriber());
+
+            for (int i = 0; i < 5; i++) {
+                var record = new WeatherRecord("Paris", 15 + ThreadLocalRandom.current().nextDouble(10), 45 + ThreadLocalRandom.current().nextDouble(20), Instant.now());
+                publisher.submit(record);
+                TimeUnit.MILLISECONDS.sleep(150);
+            }
+        }
+    }
+
+    private static final class LoggingWeatherSubscriber implements Flow.Subscriber<WeatherRecord> {
+
+        private Flow.Subscription subscription;
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.subscription = subscription;
+            subscription.request(1);
+            log("Abonnement reçu");
+        }
+
+        @Override
+        public void onNext(WeatherRecord item) {
+            log("Mesure reçue → %s %.1f°C / %.1f%%".formatted(item.city(), item.temperatureCelsius(), item.humidityPercentage()));
+            subscription.request(1);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log("Erreur : " + throwable.getMessage());
+        }
+
+        @Override
+        public void onComplete() {
+            log("Flux terminé");
+        }
+
+        private void log(String message) {
+            System.out.printf("[%s][ReactiveIntro] %s%n", Instant.now(), message);
+        }
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/CityAlert.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/CityAlert.java
@@ -1,0 +1,12 @@
+package com.example.java21.workshop.support;
+
+import java.time.Instant;
+
+/**
+ * Message envoyé lorsqu'un seuil de confort est dépassé.
+ */
+public record CityAlert(String city, double comfortIndex, Instant triggeredAt) {
+    public String formatted() {
+        return "Alerte sur %s (indice %.2f) à %s".formatted(city, comfortIndex, triggeredAt);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/CityAlertSubscriber.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/CityAlertSubscriber.java
@@ -1,0 +1,49 @@
+package com.example.java21.workshop.support;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+
+/**
+ * Abonné chargé d'afficher les alertes de confort générées par un {@link SubmissionPublisher}.
+ */
+public final class CityAlertSubscriber implements Flow.Subscriber<CityAlert> {
+
+    private final CountDownLatch completion = new CountDownLatch(1);
+    private Flow.Subscription subscription;
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        this.subscription = Objects.requireNonNull(subscription);
+        subscription.request(1);
+        log("Abonné initialisé");
+    }
+
+    @Override
+    public void onNext(CityAlert item) {
+        log("Nouvelle alerte → %s".formatted(item.formatted()));
+        subscription.request(1);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        log("Erreur dans le flux : " + throwable.getMessage());
+        completion.countDown();
+    }
+
+    @Override
+    public void onComplete() {
+        log("Flux terminé");
+        completion.countDown();
+    }
+
+    public void awaitCompletion() throws InterruptedException {
+        completion.await();
+    }
+
+    private void log(String message) {
+        System.out.printf("[%s][CityAlertSubscriber] %s%n", Instant.now(), message);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/CityReport.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/CityReport.java
@@ -1,0 +1,7 @@
+package com.example.java21.workshop.support;
+
+/**
+ * Agrégation de différentes mesures pour produire un rapport par ville.
+ */
+public record CityReport(String city, double comfortIndex, WeatherRecord weather, int trafficDelayMinutes) {
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/ComfortIndexProcessor.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/ComfortIndexProcessor.java
@@ -1,0 +1,67 @@
+package com.example.java21.workshop.support;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import java.util.concurrent.SubmissionPublisher;
+
+/**
+ * {@link Flow.Processor} qui transforme un {@link WeatherRecord} en {@link CityAlert} si l'indice de confort
+ * dépasse un seuil.
+ */
+public final class ComfortIndexProcessor extends SubmissionPublisher<CityAlert> implements Flow.Processor<WeatherRecord, CityAlert> {
+
+    private final double comfortThreshold;
+    private Flow.Subscription subscription;
+    private final Executor executor;
+    private final String name;
+
+    public ComfortIndexProcessor(double comfortThreshold, String name, Executor executor) {
+        super(executor, Flow.defaultBufferSize());
+        this.comfortThreshold = comfortThreshold;
+        this.executor = executor;
+        this.name = name;
+    }
+
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+        this.subscription = Objects.requireNonNull(subscription);
+        subscription.request(1);
+        log("Abonnement au flux météo");
+    }
+
+    @Override
+    public void onNext(WeatherRecord item) {
+        CompletableFuture.runAsync(() -> {
+            double comfortIndex = computeComfortIndex(item);
+            if (comfortIndex >= comfortThreshold) {
+                submit(new CityAlert(item.city(), comfortIndex, Instant.now()));
+            }
+            subscription.request(1);
+        }, executor);
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+        log("Erreur dans le flux météo : " + throwable.getMessage());
+        closeExceptionally(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        log("Flux météo terminé");
+        close();
+    }
+
+    private double computeComfortIndex(WeatherRecord record) {
+        double weatherScore = 100 - Math.abs(22 - record.temperatureCelsius()) * 2.5;
+        double humidityScore = 100 - Math.abs(50 - record.humidityPercentage()) * 1.1;
+        return Math.max(0, (weatherScore + humidityScore) / 2);
+    }
+
+    private void log(String message) {
+        System.out.printf("[%s][%s] %s%n", Instant.now(), name, message);
+    }
+}

--- a/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/WeatherRecord.java
+++ b/modern-java-examples/java21-concurrency/src/main/java/com/example/java21/workshop/support/WeatherRecord.java
@@ -1,0 +1,9 @@
+package com.example.java21.workshop.support;
+
+import java.time.Instant;
+
+/**
+ * Représente une mesure météo brute fournie par un capteur.
+ */
+public record WeatherRecord(String city, double temperatureCelsius, double humidityPercentage, Instant timestamp) {
+}


### PR DESCRIPTION
## Summary
- reorganize the concurrency workshop into the com.example.java21.workshop package with one standalone class per concept
- extract shared reactive utilities into a dedicated support package to reuse between demos
- refresh the README to document the new modular exercises and how to run each one

## Testing
- `mvn -pl java21-concurrency -am -DskipTests compile`


------
https://chatgpt.com/codex/tasks/task_b_68e42d37db64832aa8d43ecb34da79e7